### PR TITLE
chore: create git blame ignore

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# chore(style): configure prettier and eslint (#23)
+47d64316a2c95302e9784d99ab280c1786398968


### PR DESCRIPTION
Adds `.git-blame-ignore-revs` to hide the changes from #23 when using `blame`, because they were only stylistic changes.