### PR TITLE
fix(frontend): single fetch remix feature

### DIFF
--- a/frontend/app/components/TypeCard.tsx
+++ b/frontend/app/components/TypeCard.tsx
@@ -1,3 +1,4 @@
+import type { LinkProps } from '@remix-run/react'
 import { cx } from 'class-variance-authority'
 import { Button, InfoWithTooltip } from './index.js'
 import placeholderImg from '~/assets/images/placeholder.svg'
@@ -7,7 +8,7 @@ export type TypeCardProps = {
   title: string
   tooltip: string
   description: string
-  link: string
+  link: LinkProps['to'] | never
   bgColor: string
 }
 
@@ -19,11 +20,6 @@ export const TypeCard = ({
   link,
   bgColor
 }: TypeCardProps) => {
-  // TODO: to be removed once generators are fully migrated into tools
-  const shouldOpenInParent = ['/prob-revshare', '/link-tag'].some((path) =>
-    link.includes(path)
-  )
-
   return (
     <div className="flex flex-col shrink-0 bg-white rounded-lg w-80 p-6 border border-wm-green-shade">
       <div className={cx('flex py-6 rounded-lg bg-gradient-to-r', bgColor)}>
@@ -40,12 +36,7 @@ export const TypeCard = ({
       <p className="text-center text-sm min-h-36 p-4 mb-4 h-full">
         {description}
       </p>
-      <Button
-        intent="default"
-        aria-label={title}
-        to={link}
-        {...(shouldOpenInParent && { target: '_parent' })}
-      >
+      <Button intent="default" aria-label={title} to={link}>
         Generate
       </Button>
     </div>

--- a/frontend/app/components/TypeCard.tsx
+++ b/frontend/app/components/TypeCard.tsx
@@ -36,7 +36,7 @@ export const TypeCard = ({
       <p className="text-center text-sm min-h-36 p-4 mb-4 h-full">
         {description}
       </p>
-      <Button intent="default" aria-label={title} to={link}>
+      <Button intent="default" aria-label={title} to={link} target={'_parent'}>
         Generate
       </Button>
     </div>

--- a/frontend/app/components/TypeCard.tsx
+++ b/frontend/app/components/TypeCard.tsx
@@ -8,7 +8,7 @@ export type TypeCardProps = {
   title: string
   tooltip: string
   description: string
-  link: LinkProps['to'] | never
+  link: string
   bgColor: string
 }
 
@@ -20,6 +20,11 @@ export const TypeCard = ({
   link,
   bgColor
 }: TypeCardProps) => {
+  // TODO: to be removed once generators are fully migrated into tools
+  const shouldOpenInParent = ['/prob-revshare', '/link-tag'].some((path) =>
+    link.includes(path)
+  )
+
   return (
     <div className="flex flex-col shrink-0 bg-white rounded-lg w-80 p-6 border border-wm-green-shade">
       <div className={cx('flex py-6 rounded-lg bg-gradient-to-r', bgColor)}>
@@ -36,7 +41,12 @@ export const TypeCard = ({
       <p className="text-center text-sm min-h-36 p-4 mb-4 h-full">
         {description}
       </p>
-      <Button intent="default" aria-label={title} to={link} target={'_parent'}>
+      <Button
+        intent="default"
+        aria-label={title}
+        to={link}
+        {...(shouldOpenInParent && { target: '_parent' })}
+      >
         Generate
       </Button>
     </div>

--- a/frontend/app/components/TypeCard.tsx
+++ b/frontend/app/components/TypeCard.tsx
@@ -1,4 +1,3 @@
-import type { LinkProps } from '@remix-run/react'
 import { cx } from 'class-variance-authority'
 import { Button, InfoWithTooltip } from './index.js'
 import placeholderImg from '~/assets/images/placeholder.svg'

--- a/frontend/worker.ts
+++ b/frontend/worker.ts
@@ -19,6 +19,15 @@ export default {
         return Response.redirect(new URL(`${APP_BASEPATH}/`, request.url), 302)
       }
 
+      // handle single fetch data loading and streaming format requests
+      // part of v3_singleFetch feature flag
+      if (url.pathname === '/tools.data') {
+        return Response.redirect(
+          new URL(`${APP_BASEPATH}/tools.data`, request.url),
+          301
+        )
+      }
+
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore it may not be built during type checking stage
       const build = await import('./build/server/index.js')


### PR DESCRIPTION
### Description

Closes #122 

When using remix's `v3_singleFetch` feature flag with webmonetization.org/tools in production, single fetch data requests are made to incorrect URLs, resulting in 404 errors.

Expected Behavior
Single fetch data requests should respect the basename configuration and request:
`https://webmonetization.org/tools/tools.data`

Requested Changes
Added manual redirect handling in Cloudflare Worker.
Disabling the feature flag is also an option

Enabled feature flag context:
https://remix.run/docs/en/main/guides/single-fetch#single-fetch
