### PR TITLE
fix(frontend): trigger navigation on external tools links

### DIFF
--- a/frontend/app/components/TypeCard.tsx
+++ b/frontend/app/components/TypeCard.tsx
@@ -1,4 +1,3 @@
-import type { LinkProps } from '@remix-run/react'
 import { cx } from 'class-variance-authority'
 import { Button, InfoWithTooltip } from './index.js'
 import placeholderImg from '~/assets/images/placeholder.svg'
@@ -8,7 +7,7 @@ export type TypeCardProps = {
   title: string
   tooltip: string
   description: string
-  link: LinkProps['to'] | never
+  link: string
   bgColor: string
 }
 
@@ -20,6 +19,11 @@ export const TypeCard = ({
   link,
   bgColor
 }: TypeCardProps) => {
+  // TODO: to be removed once generators are fully migrated into tools
+  const shouldOpenInParent = ['/prob-revshare', '/link-tag'].some((path) =>
+    link.includes(path)
+  )
+
   return (
     <div className="flex flex-col shrink-0 bg-white rounded-lg w-80 p-6 border border-wm-green-shade">
       <div className={cx('flex py-6 rounded-lg bg-gradient-to-r', bgColor)}>
@@ -36,7 +40,12 @@ export const TypeCard = ({
       <p className="text-center text-sm min-h-36 p-4 mb-4 h-full">
         {description}
       </p>
-      <Button intent="default" aria-label={title} to={link}>
+      <Button
+        intent="default"
+        aria-label={title}
+        to={link}
+        {...(shouldOpenInParent && { target: '_parent' })}
+      >
         Generate
       </Button>
     </div>


### PR DESCRIPTION
### Description

A fix applied to link tag and rev share until these generators are migrated under tools repository