### PR TITLE
chore(cdn): restart cdn dev server on embed script generate

### DIFF
--- a/cdn/package.json
+++ b/cdn/package.json
@@ -14,6 +14,7 @@
     "@cloudflare/vite-plugin": "^1.1.1",
     "publisher-tools-embed": "workspace:^",
     "vite": "^6.3.5",
+    "vite-plugin-restart": "^0.4.2",
     "wrangler": "^4.16.1"
   }
 }

--- a/cdn/vite.config.ts
+++ b/cdn/vite.config.ts
@@ -1,6 +1,26 @@
+import * as path from 'node:path'
 import { defineConfig } from 'vite'
 import { cloudflare } from '@cloudflare/vite-plugin'
+import viteRestart from 'vite-plugin-restart'
+
+// https://github.com/antfu/vite-plugin-restart/issues/10#issuecomment-1155859677
+const restartOnNodeModuleChange = ['publisher-tools-embed/dist/init.js']
 
 export default defineConfig({
-  plugins: [cloudflare()]
+  plugins: [
+    cloudflare(),
+    viteRestart({
+      restart: restartOnNodeModuleChange.map((e) => `node_modules/${e}`)
+    })
+  ],
+  server: {
+    watch: {
+      ignored: restartOnNodeModuleChange.map(
+        (e) => `!${path.join(__dirname, `node_modules/${e}`)}`
+      )
+    }
+  },
+  optimizeDeps: {
+    exclude: [...restartOnNodeModuleChange]
+  }
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       vite:
         specifier: ^6.3.5
         version: 6.3.5(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1)
+      vite-plugin-restart:
+        specifier: ^0.4.2
+        version: 0.4.2(vite@6.3.5(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1))
       wrangler:
         specifier: ^4.16.1
         version: 4.16.1(@cloudflare/workers-types@4.20250507.0)
@@ -4519,6 +4522,11 @@ packages:
     resolution: {integrity: sha512-ofTf6cfRdL30Wbl9n/BX81EyIR5s4PReLmSurrxQ+koLaWUNOEo8E0lCM53OJkb8vpa2URM2nSrxZsIFyvY1rg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
+
+  vite-plugin-restart@0.4.2:
+    resolution: {integrity: sha512-9aWN2ScJ8hbT7aC8SDeZnsbWapnslz1vhNq6Vgf2GU9WdN4NExlrWhtnu7pmtOUG3Guj8y6lPcUZ+ls7SVP33w==}
+    peerDependencies:
+      vite: ^2.9.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
 
   vite-tsconfig-paths@4.3.2:
     resolution: {integrity: sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==}
@@ -9959,6 +9967,11 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vite-plugin-restart@0.4.2(vite@6.3.5(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1)):
+    dependencies:
+      micromatch: 4.0.8
+      vite: 6.3.5(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.7.1)
 
   vite-tsconfig-paths@4.3.2(typescript@5.8.3)(vite@5.4.19(@types/node@22.15.17)(lightningcss@1.29.2)):
     dependencies:


### PR DESCRIPTION
Don't have to manually restart `pnpm -C cdn dev` now on each change to embed script.