### PR TITLE
fix(frontend): add page titles and meta descriptions

### DIFF
--- a/frontend/app/routes/link-tag.tsx
+++ b/frontend/app/routes/link-tag.tsx
@@ -1,5 +1,17 @@
 import { HeadingCore, LinkTagGenerator } from '@/components'
 import { useNavigate } from '@remix-run/react'
+import type { MetaFunction } from '@remix-run/cloudflare'
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: 'Link Tag Generator - Web Monetization Tools' },
+    {
+      name: 'description',
+      content:
+        'Use the Link Tag Generator to generate a monetization <link> element for your HTML documents. Enter a payment pointer or wallet address to get started.'
+    }
+  ]
+}
 
 export default function LinkTag() {
   const navigate = useNavigate()

--- a/frontend/app/routes/prob-revshare.tsx
+++ b/frontend/app/routes/prob-revshare.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react'
 import { useNavigate } from '@remix-run/react'
+import type { MetaFunction } from '@remix-run/cloudflare'
 import {
   Card,
   CodeBlock,
@@ -26,6 +27,17 @@ import {
 } from '../lib/revshare'
 import { newShare, SharesProvider, useShares } from '../stores/revshareStore'
 import { Heading5 } from '../components/redesign/Typography'
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: 'Probabilistic Revshare - Web Monetization Tools' },
+    {
+      name: 'description',
+      content:
+        'Create a probabilistic revenue share to split Web Monetization earnings among multiple recipients.'
+    }
+  ]
+}
 
 export default function RevsharePageWrapper() {
   return (


### PR DESCRIPTION
Closes https://github.com/interledger/publisher-tools/issues/201

SEO improvements to two route components by adding meta tags for better page titles and descriptions

SEO and metadata enhancements:

* Added a `meta` export to `frontend/app/routes/link-tag.tsx` to provide a descriptive title and meta description for the Link Tag Generator page.
* Added a `meta` export to `frontend/app/routes/prob-revshare.tsx` to provide a descriptive title and meta description for the Probabilistic Revshare tool page. [[1]](diffhunk://#diff-eb3615920dbc6f5955a99252f890066c5a803a1828f83274a3c073876d745c2eR3) [[2]](diffhunk://#diff-eb3615920dbc6f5955a99252f890066c5a803a1828f83274a3c073876d745c2eR31-R41)