### PR TITLE
fix(frontend): use `font-mono` on code blocks

### DIFF
--- a/frontend/app/components/redesign/components/CodeBlock.tsx
+++ b/frontend/app/components/redesign/components/CodeBlock.tsx
@@ -1,3 +1,5 @@
+import { cx } from 'class-variance-authority'
+
 type CodeBlockProps = {
   link: string
   className?: string
@@ -5,7 +7,7 @@ type CodeBlockProps = {
 
 export const CodeBlock = ({ link, className }: CodeBlockProps) => {
   return (
-    <output className={className}>
+    <output className={cx('font-mono', className)}>
       <span>&lt;</span>
       <span style={{ color: '#00009F' }}>link </span>
       <span style={{ color: '#00A4DB' }}>rel</span>

--- a/frontend/app/components/redesign/components/ScriptReadyModal.tsx
+++ b/frontend/app/components/redesign/components/ScriptReadyModal.tsx
@@ -59,9 +59,9 @@ export const ScriptReadyModal: React.FC<ScriptReadyModalProps> = ({
         </p>
       </div>
       <div className="w-full bg-mint-50 border border-green-200 rounded-lg p-sm">
-        <p className="text-sm leading-sm font-normal text-text-primary break-all">
+        <output className="text-sm font-mono text-text-primary">
           {scriptContent}
-        </p>
+        </output>
       </div>
       <div className="w-full">
         <ToolsPrimaryButton

--- a/frontend/app/components/redesign/components/revshare/ImportTagModal.tsx
+++ b/frontend/app/components/redesign/components/revshare/ImportTagModal.tsx
@@ -140,7 +140,7 @@ export const ImportTagModal: React.FC<ImportTagModalProps> = ({
               'py-sm pl-md pr-xs rounded-lg border border-silver-300 resize-none',
               'w-full max-w-full h-[136px]',
               'focus:border-field-border-focus focus:outline-none focus:ring-1 focus:ring-primary-focus',
-              'placeholder:text-xs sm:placeholder:text-sm'
+              'placeholder:text-xs sm:placeholder:text-sm text-sm font-mono'
             )}
             placeholder={PLACEHOLDER_LINK_TAG}
             value={tag}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -217,6 +217,15 @@ export default {
           'Segoe UI Emoji',
           'Segoe UI Symbol',
           'Noto Color Emoji'
+        ],
+        mono: [
+          'ui-monospace',
+          'Cascadia Code',
+          'Source Code Pro',
+          'Menlo',
+          'Consolas',
+          'DejaVu Sans Mono',
+          'monospace'
         ]
       },
 


### PR DESCRIPTION
Font family approved by Radu M.

| Before | After |
| --- | --- |
| <img width="1845" height="651" alt="image" src="https://github.com/user-attachments/assets/0258aea4-e931-43e7-901a-0634d1772fef" /> | |
