### PR TITLE
fix(/prob-revshare): non-empty table

### DIFF
--- a/frontend/app/routes/prob-revshare.tsx
+++ b/frontend/app/routes/prob-revshare.tsx
@@ -145,7 +145,8 @@ function Revshare() {
 
   const handleRemove = useCallback(
     (index: number) => {
-      setShares(dropIndex(shares, index))
+      const newShares = dropIndex(shares, index)
+      setShares(newShares.length > 0 ? newShares : [newShare(), newShare()])
     },
     [shares, setShares]
   )


### PR DESCRIPTION
Resolves #219 for when the table is empty. Automatically will add the default of two rows to the table to better enhance the user experience