### PR TITLE
fix(frontend): fetch configs using interledger.cards WA

### DIFF
--- a/frontend/app/routes/api.config.$type.ts
+++ b/frontend/app/routes/api.config.$type.ts
@@ -41,7 +41,9 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
       return json({ errors, success: false }, { status: 400 })
     }
 
-    const ownerWalletAddress = payload.walletAddress as string
+    const ownerWalletAddress = normalizeWalletAddress(
+      await getValidWalletAddress(env, payload.walletAddress as string)
+    )
     try {
       const storageService = new ConfigStorageService(env)
       const fileContentString =


### PR DESCRIPTION
### Description

The tools could not retrieve configurations saved using a card wallet because the address was not normalized.