### PR TITLE
fix: fix rendering issues in builder; fix BuilderAccordion markup

### DIFF
--- a/frontend/app/components/redesign/components/AppearanceBuilder.tsx
+++ b/frontend/app/components/redesign/components/AppearanceBuilder.tsx
@@ -64,11 +64,8 @@ export type ToolAppearance = BannerToolAppearance | WidgetToolAppearance
 interface AppearanceBuilderProps {
   appearance: ToolAppearance
   onRefresh: () => void
-  onDone: () => void
-  isComplete?: boolean
   positionSelector?: React.ReactNode
   colorsSelector?: React.ReactNode
-  activeVersion?: string
 }
 
 function getValidSlideAnimation(value: unknown): SlideAnimationType {
@@ -80,17 +77,14 @@ function getValidSlideAnimation(value: unknown): SlideAnimationType {
 export const AppearanceBuilder: React.FC<AppearanceBuilderProps> = ({
   appearance,
   onRefresh,
-  onDone,
-  isComplete,
   positionSelector,
-  colorsSelector,
-  activeVersion
+  colorsSelector
 }) => {
   const minFontSize = 12
   const maxFontSize = 20
   const [isThumbnailVisible, setIsThumbnailVisible] = useState(true)
   const [selectedThumbnail, setSelectedThumbnail] = useState(0)
-  const { actions: uiActions } = useUI()
+  const { actions: uiActions, state: uiState } = useUI()
   const [lastSelectedAnimation, setLastSelectedAnimation] =
     useState<SlideAnimationType>(() => {
       const validated = getValidSlideAnimation(appearance.slideAnimation)
@@ -106,6 +100,7 @@ export const AppearanceBuilder: React.FC<AppearanceBuilderProps> = ({
   const thumbnails = [wmLogo]
 
   const handleToggle = (isOpen: boolean) => {
+    uiActions.setActiveSection(isOpen ? 'appearance' : null)
     if (isOpen) {
       uiActions.setAppearanceComplete(true)
     }
@@ -114,11 +109,13 @@ export const AppearanceBuilder: React.FC<AppearanceBuilderProps> = ({
   return (
     <BuilderAccordion
       title="Appearance"
-      isComplete={isComplete}
-      activeVersion={activeVersion}
+      isComplete={uiState.appearanceComplete}
       onToggle={handleToggle}
       onRefresh={onRefresh}
-      onDone={onDone}
+      onDone={() => {
+        uiActions.setAppearanceComplete(true)
+      }}
+      initialIsOpen={uiState.activeSection === 'appearance'}
     >
       <div className="flex flex-col gap-xs">
         <SectionHeader icon={<SVGText className="w-5 h-5" />} label="Text" />

--- a/frontend/app/components/redesign/components/BuilderAccordion.tsx
+++ b/frontend/app/components/redesign/components/BuilderAccordion.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState } from 'react'
+import { cx } from 'class-variance-authority'
 import { SVGArrowCollapse, SVGGreenVector, SVGRefresh } from '@/assets'
 import { GhostButton } from './GhostButton'
 import { Heading5 } from '@/typography'
@@ -9,36 +10,21 @@ interface BuilderAccordionProps {
   onRefresh: () => void
   onDone: () => void
   isComplete?: boolean
-  activeVersion?: string
+  initialIsOpen?: boolean
   onToggle?: (isOpen: boolean) => void
   children: React.ReactNode
-  className?: string
 }
 
 export const BuilderAccordion: React.FC<BuilderAccordionProps> = ({
   title,
   isComplete = false,
-  activeVersion,
+  initialIsOpen = false,
   onToggle,
   onRefresh,
   onDone,
-  children,
-  className = ''
+  children
 }) => {
-  const [isOpen, setIsOpen] = useState(false)
-  const detailsRef = useRef<HTMLDetailsElement>(null)
-  const wasOpenRef = useRef(false)
-
-  useEffect(() => {
-    if (wasOpenRef.current && detailsRef.current) {
-      detailsRef.current.open = true
-      setIsOpen(true)
-    }
-  }, [activeVersion])
-
-  useEffect(() => {
-    wasOpenRef.current = isOpen
-  }, [isOpen])
+  const [isOpen, setIsOpen] = useState(initialIsOpen)
 
   const handleToggle = (e: React.SyntheticEvent<HTMLDetailsElement>) => {
     const isOpen = e.currentTarget.open
@@ -46,55 +32,42 @@ export const BuilderAccordion: React.FC<BuilderAccordionProps> = ({
     onToggle?.(isOpen)
   }
 
-  const handleRefresh = (e: React.MouseEvent) => {
-    e.stopPropagation()
-    onRefresh()
-  }
-
   const handleDoneClick = () => {
     setIsOpen(false)
-    if (detailsRef.current) {
-      detailsRef.current.open = false
-    }
-
     onDone()
   }
 
   return (
     <details
-      ref={detailsRef}
-      key={activeVersion}
+      open={isOpen}
       name="builder-accordion"
-      className={`flex flex-col rounded-lg transition-transform duration-300 ease-in-out relative ${
+      className={cx(
+        'flex flex-col rounded-lg relative',
+        'transition-transform duration-300 ease-in-out',
         isOpen ? 'bg-interface-bg-container' : 'bg-interface-bg-main'
-      } ${className}`}
+      )}
       onToggle={handleToggle}
     >
       <summary
-        className={`flex items-center justify-between cursor-pointer transition-all duration-300 ease-in-out list-none ${
+        className={cx(
+          'flex gap-xs items-center cursor-pointer list-none',
+          'transition-all duration-300 ease-in-out',
           isOpen ? 'px-2xs py-xs' : 'pl-md pr-2xs py-xs'
-        }`}
+        )}
       >
-        <div className="flex items-center gap-xs">
-          {isComplete && !isOpen && <SVGGreenVector className="w-6 h-[18px]" />}
-          <Heading5>{title}</Heading5>
-        </div>
+        {isComplete && !isOpen && <SVGGreenVector className="w-6 h-[18px]" />}
+        <Heading5>{title}</Heading5>
 
-        <div className="flex gap-xs">
-          <div
-            className={`w-12 h-12 rounded-lg flex items-center justify-center ${
-              !isOpen ? 'rotate-180' : ''
-            }`}
-          >
-            <SVGArrowCollapse className="w-5 h-5" />
-          </div>
-        </div>
+        <SVGArrowCollapse
+          className={cx('w-12 h-12 p-3.5 ml-auto', !isOpen && 'rotate-180')}
+        />
       </summary>
 
       {isOpen && (
         <GhostButton
+          type="button"
           className="absolute top-2 right-14 w-12 h-12 z-10 p-0"
-          onClick={handleRefresh}
+          onClick={onRefresh}
           aria-label={`Reset ${title.toLowerCase()} to default`}
         >
           <SVGRefresh className="w-6 h-6" />

--- a/frontend/app/components/redesign/components/BuilderForm.tsx
+++ b/frontend/app/components/redesign/components/BuilderForm.tsx
@@ -26,7 +26,7 @@ export const BuilderForm: React.FC<BuilderFormProps> = ({
   colorsSelector
 }) => {
   const snap = useSnapshot(toolState)
-  const { state: uiState, actions: uiActions } = useUI()
+  const { state: uiState } = useUI()
 
   useEffect(() => {
     const bothComplete = uiState.contentComplete && uiState.appearanceComplete
@@ -41,14 +41,6 @@ export const BuilderForm: React.FC<BuilderFormProps> = ({
 
   const handleTabLabelChange = (stableKey: StableKey, newLabel: string) => {
     toolActions.updateVersionLabel(stableKey, newLabel)
-  }
-
-  const handleContentDone = () => {
-    uiActions.setContentComplete(true)
-  }
-
-  const handleAppearanceDone = () => {
-    uiActions.setAppearanceComplete(true)
   }
 
   return (
@@ -69,23 +61,18 @@ export const BuilderForm: React.FC<BuilderFormProps> = ({
         flex flex-col gap-md
         w-full
         ${className}
-      `}
+        `}
+        key={snap.activeVersion}
       >
         <ContentBuilder
-          isComplete={uiState.contentComplete}
-          onDone={handleContentDone}
           onRefresh={() => onRefresh('content')}
           content={content}
-          activeVersion={snap.activeVersion}
         />
         <AppearanceBuilder
-          isComplete={uiState.appearanceComplete}
-          onDone={handleAppearanceDone}
           onRefresh={() => onRefresh('appearance')}
           appearance={appearance}
           positionSelector={positionSelector}
           colorsSelector={colorsSelector}
-          activeVersion={snap.activeVersion}
         />
       </div>
     </div>

--- a/frontend/app/components/redesign/components/ContentBuilder.tsx
+++ b/frontend/app/components/redesign/components/ContentBuilder.tsx
@@ -29,23 +29,16 @@ export interface ToolContent {
 interface ContentBuilderProps {
   content: ToolContent
   onRefresh: () => void
-  onDone: () => void
-  isComplete?: boolean
-  className?: string
-  activeVersion?: string
 }
 
 export const ContentBuilder: React.FC<ContentBuilderProps> = ({
   content,
-  isComplete,
-  onDone,
-  onRefresh,
-  activeVersion
+  onRefresh
 }) => {
   const [isMessageActive, setIsMessageActive] = useState(true)
   const titleInputRef = useRef<HTMLInputElement>(null)
   const messageTextareaRef = useRef<HTMLTextAreaElement>(null)
-  const { actions: uiActions } = useUI()
+  const { actions: uiActions, state: uiState } = useUI()
 
   useEffect(() => {
     if (
@@ -64,6 +57,7 @@ export const ContentBuilder: React.FC<ContentBuilderProps> = ({
   }, [content.currentTitle, content.currentMessage])
 
   const handleToggle = (isOpen: boolean) => {
+    uiActions.setActiveSection(isOpen ? 'content' : null)
     if (isOpen) {
       uiActions.setContentComplete(true)
     }
@@ -72,11 +66,13 @@ export const ContentBuilder: React.FC<ContentBuilderProps> = ({
   return (
     <BuilderAccordion
       title="Content"
-      isComplete={isComplete}
-      activeVersion={activeVersion}
+      isComplete={uiState.contentComplete}
       onToggle={handleToggle}
       onRefresh={onRefresh}
-      onDone={onDone}
+      onDone={() => {
+        uiActions.setContentComplete(true)
+      }}
+      initialIsOpen={uiState.activeSection === 'content'}
     >
       <div className="flex flex-col gap-lg">
         <div className="flex flex-col gap-xs">

--- a/frontend/app/stores/uiStore.tsx
+++ b/frontend/app/stores/uiStore.tsx
@@ -11,6 +11,7 @@ import type { ReactNode } from 'react'
 type UIState = {
   contentComplete: boolean
   appearanceComplete: boolean
+  activeSection: 'content' | 'appearance' | null
 }
 
 interface WalletInputRef {
@@ -22,6 +23,7 @@ interface UIActions {
   registerWalletInput: (ref: WalletInputRef) => () => void
   setContentComplete: (complete: boolean) => void
   setAppearanceComplete: (complete: boolean) => void
+  setActiveSection: (section: UIState['activeSection']) => void
 }
 
 interface UIContextType {
@@ -40,6 +42,8 @@ export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
   const [shouldFocusWallet, setShouldFocusWallet] = useState(false)
   const [contentComplete, setContentComplete] = useState(false)
   const [appearanceComplete, setAppearanceComplete] = useState(false)
+  const [activeSection, setActiveSection] =
+    useState<UIState['activeSection']>(null)
 
   useEffect(() => {
     if (shouldFocusWallet && walletInputRef.current) {
@@ -62,6 +66,7 @@ export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
 
   const state: UIState = {
     contentComplete,
+    activeSection,
     appearanceComplete
   }
 
@@ -69,7 +74,8 @@ export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
     focusWalletInput,
     registerWalletInput,
     setContentComplete,
-    setAppearanceComplete
+    setAppearanceComplete,
+    setActiveSection
   }
 
   return (


### PR DESCRIPTION
Extracted from https://github.com/interledger/publisher-tools/pull/253

- Move `key` to higher level in `BuilderForm` to correctly re-render on tab change
- Fix markup of `BuilderAccordion`, as `<summary>` isn't allowed to contain `<div>`
- Reduce state in `BuilderAccordion`, making it simpler (no `ref` or `useEffect` needed anymore)
- Maintain open section (content/appearance) when preset tab is switched.