### PR TITLE
fix(frontend): prevent crash on validation error during save

### DIFF
--- a/frontend/app/components/redesign/components/SaveResultModal.tsx
+++ b/frontend/app/components/redesign/components/SaveResultModal.tsx
@@ -54,7 +54,7 @@ export const SaveResultModal: React.FC<SaveResultModalProps> = ({
         )}
       </div>
       <div className="text-center">
-        <p className="text-base leading-md font-normal text-text-primary">
+        <p className="text-base leading-md font-normal text-text-primary whitespace-pre-wrap">
           {message}
         </p>
       </div>

--- a/frontend/app/lib/presets.ts
+++ b/frontend/app/lib/presets.ts
@@ -37,6 +37,7 @@ export const modalTypes = [
 ]
 export type ModalType = {
   type: (typeof modalTypes)[number]
+  message?: string; // set when type is "save-error"
   grantRedirectIntent?: string
   grantRedirectURI?: string
   fetchedConfigs?: Record<string, ElementConfigType>

--- a/frontend/app/routes/api.config.$type.ts
+++ b/frontend/app/routes/api.config.$type.ts
@@ -93,10 +93,11 @@ export async function action({ request, params, context }: ActionFunctionArgs) {
 
   const { result, payload } = await validateForm(entries, elementType)
   if (!result.success || !payload) {
+    const message = result.error?.message
     errors.fieldErrors = result.error?.flatten().fieldErrors || {
       walletAddress: undefined
     }
-    return json({ errors, success: false, intent }, { status: 400 })
+    return json({ message, errors, success: false, intent }, { status: 400 })
   }
 
   let ownerWalletAddress: string = payload.walletAddress

--- a/frontend/app/routes/banner.tsx
+++ b/frontend/app/routes/banner.tsx
@@ -284,8 +284,24 @@ export default function Banner() {
     const setLoading = isScript ? setIsLoadingScript : setIsLoading
 
     setLoading(true)
-    await toolActions.saveConfig(action)
-    setLoading(false)
+    try {
+      await toolActions.saveConfig(action)
+    } catch (err) {
+      const error = err as Error
+      console.error({ error })
+      let message = error.message
+      // @ts-expect-error TODO
+      const fieldErrors = error.cause?.details?.errors?.fieldErrors
+      if (fieldErrors) {
+        message += '\n'
+        for (const [key, msg] of Object.entries(fieldErrors)) {
+          message += `\n${key}: ${msg}`
+        }
+      }
+      toolActions.setModal({ type: 'save-error', message })
+    } finally {
+      setLoading(false)
+    }
   }
 
   const handlePreviewClick = () => {
@@ -502,9 +518,10 @@ export default function Banner() {
                 onClose={handleCloseModal}
                 onDone={handleCloseModal}
                 message={
-                  !snap.isGrantAccepted
+                  snap.modal?.message ||
+                  (!snap.isGrantAccepted
                     ? String(snap.grantResponse)
-                    : 'Error saving your edits'
+                    : 'Error saving your edits')
                 }
                 isSuccess={snap.isGrantAccepted}
               />

--- a/frontend/app/stores/toolStore.ts
+++ b/frontend/app/stores/toolStore.ts
@@ -396,6 +396,12 @@ export const toolActions = {
         method: 'PUT',
         body: formData
       })
+      if (!response.ok) {
+        const details = await response.json()
+        throw new Error(`Save request failed with status: ${response.status}`, {
+          cause: { details }
+        })
+      }
 
       const data = (await response.json()) as SaveConfigResponse
 


### PR DESCRIPTION
When there was a validation error in config while saving, we didn't handle the `!response.ok` state. We ended up saving error the error message in localStorage, leading to crash (see "Before" screenshot below). Now, prevent saving error response in localStorage when backend save fails.

Showing the specific error in modal so user may have some hint what went wrong.

| Before | After |
| --- | --- |
| <img width="1224" height="468" alt="image" src="https://github.com/user-attachments/assets/b8f30de4-0d07-462c-91a3-f0cc9e0018ae" /> | <img width="1224" height="468" alt="image" src="https://github.com/user-attachments/assets/9da5cfe6-3709-4b1d-b830-81178ac6ee99" /> |

This needs to be fixed as a part of fixing how we handle state across the app, but for now, we can prevent the indefinite crash, giving user some agency.