### PR TITLE
fix(/link-tag): don't open docs in new tab

### DIFF
--- a/frontend/app/routes/link-tag.tsx
+++ b/frontend/app/routes/link-tag.tsx
@@ -13,8 +13,6 @@ export const meta: MetaFunction = () => {
   ]
 }
 
-const WEB_MONETIZATION_URL = 'https://webmonetization.org'
-
 export default function LinkTag() {
   const navigate = useNavigate()
   return (
@@ -30,7 +28,7 @@ export default function LinkTag() {
             payment pointer
           </a>
           &nbsp;or&nbsp;
-          <a href={`${WEB_MONETIZATION_URL}/wallets/`} className="underline">
+          <a href="https://webmonetization.org/wallets/" className="underline">
             wallet address
           </a>
           &nbsp;into the field and click Generate.
@@ -53,7 +51,7 @@ export default function LinkTag() {
             Visit our&nbsp;
             <a
               className="text-style-body-standard !text-text-buttons-default underline"
-              href={`${WEB_MONETIZATION_URL}/docs/`}
+              href="https://webmonetization.org/docs/"
             >
               docs
             </a>


### PR DESCRIPTION
Resolves https://github.com/interledger/publisher-tools/issues/257

For reviewer:
Could also go route of using relative path `href="/docs/"` as it will eventually be on https://webmonetization.org - just wouldn't work when testing locally
