### PR TITLE
fix(ci/deploy): typo in EVENT_NAME when finding deploy mode

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
           GH_EVENT_NAME='${{ github.event_name }}'
           GH_REF='${{ github.ref }}'
           mode="preview"
-          if [[ "$EVENT_NAME" == 'push' ]]; then
+          if [[ "$GH_EVENT_NAME" == 'push' ]]; then
             [[ "$GH_REF" == 'refs/heads/main' ]] && mode="staging"
             [[ "$GH_REF" == 'refs/heads/release' ]] && mode="production"
           fi


### PR DESCRIPTION
Missed in https://github.com/interledger/publisher-tools/pull/265. Meant staging/production deploy mode was never getting set.