### PR TITLE
refactor: add shared probabilistic-revenue-share package

### DIFF
--- a/frontend/app/lib/revshare.ts
+++ b/frontend/app/lib/revshare.ts
@@ -1,4 +1,9 @@
-import { generateShareId } from '@shared/utils'
+import {
+  decode,
+  encode,
+  type PayloadEntry
+} from '@shared/probabilistic-revenue-share'
+
 const BASE_REVSHARE_POINTER = '$webmonetization.org/api/revshare/pay/'
 const POINTER_LIST_PARAM = 'p'
 const CHART_COLORS = [
@@ -15,15 +20,9 @@ const CHART_COLORS = [
 ]
 
 /** Represents a single revenue share participant */
-export type Share = {
+export interface Share extends PayloadEntry {
   /** Unique identifier for the share */
   id: string
-  /** An optional name for the recipient for display purposes */
-  name?: string
-  /** The payment pointer or wallet address of the recipient */
-  pointer: string
-  /** The numerical weight of the share, used to calculate the distribution */
-  weight?: number
   /** The percentage of revenue this share should receive, if applicable */
   percent?: number
   /** Indicates if the share is valid, used for validation purposes */
@@ -40,6 +39,10 @@ export type SharesState = Share[]
  */
 export function getValidShares(shares: Share[]): SharesState {
   return shares.filter((share) => share.pointer && Number(share.weight))
+}
+
+export function generateShareId(): string {
+  return `share-${Date.now()}-${Math.random().toString(36).slice(2)}`
 }
 
 /**
@@ -118,39 +121,6 @@ export function dropIndex(arr: SharesState, i: number): SharesState {
 }
 
 /**
- * Calculates the required weight for a share to achieve a target percentage of the total
- * @param percent - The target percentage (0 to 1)
- * @param weight - The current weight of the share
- * @param totalWeight - The total weight of all shares
- * @returns The required weight to achieve the target percentage
- */
-export function weightFromPercent(
-  percent: number,
-  weight: number,
-  totalWeight: number
-): number {
-  return (-percent * (totalWeight - weight)) / (percent - 1)
-}
-
-/**
- * Encodes a string into a URL-safe base64 format
- * @param str - The string to encode
- * @returns URL-safe base64 encoded string
- */
-export function base64url(str: string): string {
-  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
-}
-
-/**
- * Decodes a URL-safe base64 string back to its original format
- * @param str - The URL-safe base64 string to decode
- * @returns Decoded original string
- */
-export function fromBase64url(str: string): string {
-  return atob(str.replace(/-/g, '+').replace(/_/g, '/'))
-}
-
-/**
  * Constructs a complete revshare payment pointer from an array of shares
  * @param shares - Array of shares to convert into a payment pointer
  * @returns Complete revshare payment pointer string, or undefined if no valid shares
@@ -162,9 +132,7 @@ export function sharesToPaymentPointer(shares: Share[]): string | undefined {
     return
   }
 
-  const pointerList = sharesToPointerList(validShares)
-  const encodedShares = base64url(JSON.stringify(pointerList))
-
+  const encodedShares = encode(validShares)
   return normalizePointerPrefix(BASE_REVSHARE_POINTER) + encodedShares
 }
 
@@ -189,14 +157,11 @@ export function pointerToShares(pointer: string): SharesState {
       )
     }
 
-    const pointerList = JSON.parse(fromBase64url(encodedList))
-
-    if (!validatePointerList(pointerList)) {
-      throw new Error(
-        'Share data is invalid. Make sure you copy the whole "content" from your meta tag.'
-      )
-    }
-    return sharesFromPointerList(pointerList as [string, number, string][])
+    const decoded = decode(encodedList)
+    return decoded.map((e) => ({
+      ...e,
+      id: generateShareId()
+    }))
   } catch (err: unknown) {
     if (err instanceof TypeError) {
       throw new Error('Meta tag or payment pointer is malformed')
@@ -216,7 +181,7 @@ export function pointerToShares(pointer: string): SharesState {
  * @returns Array of Share objects, or undefined if no valid monetization tag found
  * @throws Error if the tag is malformed
  */
-export function tagToShares(tag: string): SharesState | undefined {
+export function tagToShares(tag: string): SharesState {
   const parser = new DOMParser()
   const node = parser.parseFromString(tag, 'text/html')
   const meta = node.head.querySelector(
@@ -226,12 +191,6 @@ export function tagToShares(tag: string): SharesState | undefined {
     'link[rel="monetization"]'
   ) as HTMLLinkElement
 
-  if (!meta && !link) {
-    throw new Error(
-      'Please enter the exact link tag you generated from this revshare tool. It seems to be malformed.'
-    )
-  }
-
   if (meta) {
     return pointerToShares(meta.content)
   }
@@ -239,6 +198,10 @@ export function tagToShares(tag: string): SharesState | undefined {
   if (link) {
     return pointerToShares(link.href)
   }
+
+  throw new Error(
+    'Please enter the exact link tag you generated from this revshare tool. It seems to be malformed.'
+  )
 }
 
 /**
@@ -273,83 +236,12 @@ export function tagOrPointerToShares(tag: string): SharesState | undefined {
 }
 
 /**
- * Trims a decimal number to 3 decimal places
- * @param dec - The decimal number to trim
- * @returns Number rounded to 3 decimal places
- */
-export function trimDecimal(dec: number): number {
-  return Number(dec.toFixed(3))
-}
-
-/**
- * Validates if a given pointer list is an array of [string, number, string?] tuples
- * @param pointerList - The value to validate
- * @returns True if the pointer list is valid, with type guard
- */
-export function validatePointerList(
-  pointerList: unknown
-): pointerList is [string, number, string?][] {
-  if (!Array.isArray(pointerList)) {
-    return false
-  }
-
-  for (const entry of pointerList) {
-    if (
-      !Array.isArray(entry) ||
-      typeof entry[0] !== 'string' ||
-      typeof entry[1] !== 'number' ||
-      (entry[2] !== undefined && typeof entry[2] !== 'string')
-    ) {
-      return false
-    }
-  }
-
-  return true
-}
-
-/**
  * Normalizes a payment pointer prefix, converting `$` to `https://`
  * @param pointer - The payment pointer to normalize
  * @returns Payment pointer with https:// prefix
  */
 export function normalizePointerPrefix(pointer: string): string {
   return pointer.startsWith('$') ? 'https://' + pointer.substring(1) : pointer
-}
-
-/**
- * Validates if a given pointer is a valid URL or payment pointer
- * @param pointer - The pointer string to validate (can be undefined)
- * @returns True if the pointer is valid or undefined, false otherwise
- */
-export function validatePointer(pointer: string | undefined): boolean {
-  if (!pointer) {
-    return true
-  }
-
-  if (typeof pointer !== 'string') {
-    return false
-  }
-
-  try {
-    const _ = new URL(normalizePointerPrefix(pointer))
-    return true
-  } catch (_err) {
-    return false
-  }
-}
-
-/**
- * Validates if a given weight is a valid number greater than or equal to 0
- * @param weight - The weight value to validate (string, number, or undefined)
- * @returns True if the weight is valid (undefined, empty string, or non-negative number)
- */
-export function validateWeight(weight: string | number | undefined): boolean {
-  if (weight === undefined || weight === '') {
-    return true
-  }
-
-  const num = Number(weight)
-  return !Number.isNaN(num) && num >= 0
 }
 
 export function validateShares(shares: SharesState): boolean {

--- a/frontend/app/stores/revshareStore.tsx
+++ b/frontend/app/stores/revshareStore.tsx
@@ -1,8 +1,11 @@
 import type { ReactNode } from 'react'
 import { useContext, useState, createContext, useEffect, useMemo } from 'react'
-import type { SharesState, Share } from '../lib/revshare'
-import { validateShares } from '../lib/revshare'
-import { generateShareId } from '@shared/utils'
+import {
+  generateShareId,
+  validateShares,
+  type Share,
+  type SharesState
+} from '../lib/revshare'
 
 const SHARES_KEY = 'prob-revshare-shares'
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@remix-run/cloudflare": "^2.16.6",
     "@remix-run/react": "^2.16.6",
     "@shared/config-storage-service": "workspace:^",
+    "@shared/probabilistic-revenue-share": "workspace:^",
     "@shared/utils": "workspace:^",
     "@tailwindcss/postcss": "^4.1.6",
     "@tippyjs/react": "^4.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       '@shared/config-storage-service':
         specifier: workspace:^
         version: link:../shared/config-storage-service
+      '@shared/probabilistic-revenue-share':
+        specifier: workspace:^
+        version: link:../shared/probabilistic-revenue-share
       '@shared/utils':
         specifier: workspace:^
         version: link:../shared/utils
@@ -309,6 +312,8 @@ importers:
         version: link:../types
 
   shared/defines: {}
+
+  shared/probabilistic-revenue-share: {}
 
   shared/types: {}
 
@@ -6077,7 +6082,7 @@ snapshots:
 
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.14.1
+      acorn: 8.15.0
     optional: true
 
   acorn@8.14.0: {}
@@ -9474,7 +9479,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 22.15.17
-      acorn: 8.14.1
+      acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1

--- a/shared/probabilistic-revenue-share/index.ts
+++ b/shared/probabilistic-revenue-share/index.ts
@@ -1,0 +1,84 @@
+export interface PayloadEntry {
+  /** The payment pointer or wallet address of the recipient */
+  pointer: string
+  /** The numerical weight of the share, used to calculate the distribution */
+  weight: number
+  /** An optional name for the recipient for display purposes */
+  name?: string
+}
+
+/** Represents the state of all shares in the revenue distribution */
+export type Payload = PayloadEntry[]
+
+type PointerList = Array<[pointer: string, weight: number, name: string]>
+
+export function encode(payload: Payload) {
+  const pointerList: Array<[pointer: string, weight: number, name: string]> =
+    payload.flatMap((e) =>
+      e.pointer && e.weight ? [[e.pointer, Number(e.weight), e.name || '']] : []
+    )
+  return base64url(JSON.stringify(pointerList))
+}
+
+export function decode(pathPart: string): Payload {
+  let stringifiedPointerList
+  try {
+    stringifiedPointerList = fromBase64url(pathPart)
+  } catch {
+    throw new Error('Invalid base64url payload')
+  }
+
+  let pointerList
+  try {
+    pointerList = JSON.parse(stringifiedPointerList)
+  } catch {
+    throw new Error('Invalid JSON payload')
+  }
+
+  if (!isPointerList(pointerList)) {
+    throw new Error('Invalid payload')
+  }
+
+  return pointerList.map(([pointer, weight, name]) => ({
+    pointer,
+    weight,
+    name
+  }))
+}
+
+function isPointerList(pointerList: unknown): pointerList is PointerList {
+  if (!Array.isArray(pointerList)) {
+    return false
+  }
+
+  for (const entry of pointerList) {
+    if (
+      !Array.isArray(entry) ||
+      typeof entry[0] !== 'string' ||
+      typeof entry[1] !== 'number' ||
+      (entry[2] !== undefined && typeof entry[2] !== 'string')
+    ) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * Encodes a string into a URL-safe base64 format
+ * @param str - The string to encode
+ * @returns URL-safe base64 encoded string
+ */
+export function base64url(str: string): string {
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+}
+
+/**
+ * Decodes a URL-safe base64 string back to its original format
+ * @param str - The URL-safe base64 string to decode
+ * @returns Decoded original string
+ */
+export function fromBase64url(str: string): string {
+  return atob(str.replace(/-/g, '+').replace(/_/g, '/'))
+}

--- a/shared/probabilistic-revenue-share/package.json
+++ b/shared/probabilistic-revenue-share/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@shared/probabilistic-revenue-share",
+  "version": "0.0.1",
+  "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "private": true
+}

--- a/shared/utils/index.ts
+++ b/shared/utils/index.ts
@@ -197,10 +197,6 @@ export async function validateAndConfirmPointer(url: string): Promise<string> {
   return validUrl
 }
 
-export function generateShareId(): string {
-  return `share-${Date.now()}-${Math.random().toString(36).slice(2)}`
-}
-
 export function groupBy<T, K extends PropertyKey>(
   items: T[],
   keySelector: (item: T) => K


### PR DESCRIPTION
- Part of https://github.com/interledger/publisher-tools/issues/85
- Extracted from https://github.com/interledger/publisher-tools/pull/282

---

- Add shared package with encode/decode functions and some common revshare types
- Use them in frontend
- Remove unused revshare functions from frontend

---

Follow up:
- @sidvishnoi To use the shared function in API, while fixing the security issues
- @DarianM To use the shared `decode` functionality in Remix backend when importing link tag.