### PR TITLE
fix(components/banner): use same color for close button as text

### DIFF
--- a/components/src/banner.css
+++ b/components/src/banner.css
@@ -243,7 +243,7 @@
   background: none;
   border: none;
   cursor: pointer;
-  color: #6b7280;
+  color: var(--text-color, #6b7280);
   width: 24px;
   height: 24px;
   display: flex;
@@ -273,7 +273,8 @@
   }
 }
 
-.close-button:hover {
+.close-button:hover,
+.close-button:focus {
   background-color: #f3f4f6;
   color: #374151;
 }


### PR DESCRIPTION
Closes https://github.com/interledger/publisher-tools/issues/284

Using same color as text, instead of going for a color-contrast based logic, as we expect user to choose the colors such that text is visible properly.

The color pickers could in future cause a validation failure if colors picked by user don't have good contrast.