### PR TITLE
fix(api)!: remove `/tools` path prefix from API

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -79,7 +79,7 @@ app.onError((error, c) => {
 })
 
 app.get(
-  '/tools/config/:wa/:version?',
+  '/config/:wa/:version?',
   zValidator('param', WalletAddressParamSchema),
   async ({ req, json, env }) => {
     const { wa, version } = req.valid('param')
@@ -95,7 +95,7 @@ app.get(
 )
 
 app.post(
-  '/tools/payment/quote',
+  '/payment/quote',
   zValidator('json', PaymentQuoteSchema),
   async ({ req, json, env }) => {
     try {
@@ -118,7 +118,7 @@ app.post(
 )
 
 app.post(
-  '/tools/payment/grant',
+  '/payment/grant',
   zValidator('json', PaymentGrantSchema),
   async ({ req, json, env }) => {
     try {
@@ -144,7 +144,7 @@ app.post(
 )
 
 app.post(
-  '/tools/payment/finalize',
+  '/payment/finalize',
   zValidator('json', PaymentFinalizeSchema),
   async ({ req, json, env }) => {
     try {
@@ -175,7 +175,7 @@ app.post(
 )
 
 app.get(
-  '/tools/revshare/:payload',
+  '/revshare/:payload',
   zValidator('param', probabilisticRevShare.paramSchema),
   async ({ req, json }) => {
     const encodedPayload = req.param('payload')

--- a/components/src/widget/views/confirmation/confirmation.ts
+++ b/components/src/widget/views/confirmation/confirmation.ts
@@ -166,7 +166,7 @@ export class PaymentConfirmation extends LitElement {
     amount: number
   }): Promise<void> {
     const { apiUrl } = this.configController.config
-    const url = new URL(`/tools/payment/quote`, apiUrl)
+    const url = new URL(`/payment/quote`, apiUrl)
     const response = await fetch(url, {
       method: 'POST',
       headers: {
@@ -268,7 +268,7 @@ export class PaymentConfirmation extends LitElement {
     receiveAmount: Amount
   }): Promise<PendingGrant> {
     const { apiUrl, frontendUrl } = this.configController.config
-    const url = new URL('/tools/payment/grant', apiUrl).href
+    const url = new URL('/payment/grant', apiUrl).href
     const redirectUrl = new URL('payment-confirmation', frontendUrl).href
 
     const response = await fetch(url, {

--- a/components/src/widget/views/interaction/interaction.ts
+++ b/components/src/widget/views/interaction/interaction.ts
@@ -91,7 +91,7 @@ export class PaymentInteraction extends LitElement {
         note
       } = this.configController.state
       const { apiUrl } = this.configController.config
-      const url = new URL('/tools/payment/finalize', apiUrl).href
+      const url = new URL('/payment/finalize', apiUrl).href
       const response = await fetch(url, {
         method: 'POST',
         headers: {

--- a/embed/src/index.ts
+++ b/embed/src/index.ts
@@ -39,7 +39,7 @@ if (!paramTypes || !paramWallet) {
   throw 'Missing parameters! Could not initialise WM Tools.'
 }
 
-fetch(`${API_URL}/tools/config/${urlWallet}/${paramTag}`)
+fetch(`${API_URL}/config/${urlWallet}/${paramTag}`)
   .then((response) => response.json())
   .then((resp) => {
     const config = resp

--- a/frontend/app/lib/revshare.ts
+++ b/frontend/app/lib/revshare.ts
@@ -182,7 +182,7 @@ function isRevsharePointer(str: string): boolean {
     return false
   }
 
-  if (url.pathname.startsWith('/tools/revshare/')) {
+  if (url.pathname.startsWith('/revshare/')) {
     return true
   }
   // older version

--- a/frontend/app/routes/prob-revshare.tsx
+++ b/frontend/app/routes/prob-revshare.tsx
@@ -36,7 +36,7 @@ export const meta: MetaFunction = () => {
   ]
 }
 
-const baseUrl = new URL('/tools/revshare/', API_URL).href
+const baseUrl = new URL('/revshare/', API_URL).href
 
 export default function RevsharePageWrapper() {
   return (


### PR DESCRIPTION
As discussed on [Slack](https://interledgerfoundation.slack.com/archives/C08FYR2GSPP/p1757922138234349).

> I'm thinking of removing the /tools path suffix from tools CDN and API, and instead include tools in subdomain. Presently, we've `cdn.webmonetization.org/tools/*` and `api.webmonetization.org/tools/*`.
> 
> These subdomains are bit too abstract and it can seem like the api is for "Web Monetization API".
>
> The initial idea was, we'll add more things on same the subdomains, but having separate subdomains is more manageable as the projects and deployments are different. It's presently relatively easy to manage with Cloudflare (using worker routes), but why set ourselves up with a vendor lock-in?
>
> So, I'll replace:
> - `cdn.webmonetization.org/tools` with `tools-cdn.webmonetization.org`
> - `api.webmonetization.org/tools` with `tools-api.webmonetization.org`
>
> From @sidvishnoi 