### PR TITLE
fix: turn `AWS_PREFIX` to build-time constant

### DIFF
--- a/.github/workflows/deploy-worker/action.yml
+++ b/.github/workflows/deploy-worker/action.yml
@@ -37,6 +37,9 @@ inputs:
   BUILD_CDN_URL:
     description: 'CDN_URL from deploying cdn'
     required: false
+  BUILD_AWS_PREFIX:
+    description: 'AWS_PREFIX used for config storage'
+    required: true
 
 outputs:
   url:
@@ -60,6 +63,7 @@ runs:
         NODE_ENV: production
         BUILD_API_URL: ${{ inputs.BUILD_API_URL }}
         BUILD_CDN_URL: ${{ inputs.BUILD_CDN_URL }}
+        BUILD_AWS_PREFIX: ${{ inputs.BUILD_AWS_PREFIX }}
 
     - name: Get worker deploy command
       if: inputs.changed == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,6 +81,7 @@ jobs:
           name: 'api'
           changed: ${{ steps.changes.outputs.api }}
           mode: ${{ steps.deploy-mode.outputs.mode }}
+          BUILD_AWS_PREFIX: ${{ vars.AWS_PREFIX }}
           stagingUrl: ${{ vars.API_STAGING_URL }}
           productionUrl: ${{ vars.API_PRODUCTION_URL }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -95,6 +96,7 @@ jobs:
           mode: ${{ steps.deploy-mode.outputs.mode }}
           build: 'pnpm -C embed run build && pnpm -C cdn run build'
           BUILD_API_URL: ${{ steps.api.outputs.url }}
+          BUILD_AWS_PREFIX: ${{ vars.AWS_PREFIX }}
           stagingUrl: ${{ vars.CDN_STAGING_URL }}
           productionUrl: ${{ vars.CDN_PRODUCTION_URL }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -110,6 +112,7 @@ jobs:
           build: 'pnpm -C frontend run build'
           BUILD_API_URL: ${{ steps.api.outputs.url }}
           BUILD_CDN_URL: ${{ steps.cdn.outputs.url }}
+          BUILD_AWS_PREFIX: ${{ vars.AWS_PREFIX }}
           stagingUrl: ${{ vars.APP_STAGING_URL }}
           productionUrl: ${{ vars.APP_PRODUCTION_URL }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -4,7 +4,7 @@ import { zValidator } from '@hono/zod-validator'
 import { HTTPException } from 'hono/http-exception'
 import { ZodError } from 'zod'
 import { ConfigStorageService } from '@shared/config-storage-service'
-import { APP_URL } from '@shared/defines'
+import { APP_URL, AWS_PREFIX } from '@shared/defines'
 import type { ConfigVersions } from '@shared/types'
 import * as probabilisticRevShare from './routes/probabilistic-revshare.js'
 import { OpenPaymentsService } from './utils/open-payments.js'
@@ -21,7 +21,6 @@ export type Env = {
   AWS_SECRET_ACCESS_KEY: string
   AWS_REGION: string
   AWS_BUCKET_NAME: string
-  AWS_PREFIX: string
   OP_WALLET_ADDRESS: string
   OP_PRIVATE_KEY: string
   OP_KEY_ID: string
@@ -85,7 +84,7 @@ app.get(
     const { wa, version } = req.valid('param')
 
     try {
-      const storageService = new ConfigStorageService(env)
+      const storageService = new ConfigStorageService({ ...env, AWS_PREFIX })
       const config = await storageService.getJson<ConfigVersions>(wa)
       return json(config[version])
     } catch (error) {

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -6,3 +6,6 @@ compatibility_flags = ["nodejs_compat"]
 [vars]
 FRONTEND_URL = "https://webmonetization.org/tools/"
 AWS_PREFIX = "20250717"
+
+[dev]
+port = 8787

--- a/frontend/app/lib/types.ts
+++ b/frontend/app/lib/types.ts
@@ -62,6 +62,5 @@ declare global {
     AWS_SECRET_ACCESS_KEY: string
     AWS_REGION: string
     AWS_BUCKET_NAME: string
-    AWS_PREFIX: string
   }
 }

--- a/frontend/app/routes/api.config.$type.ts
+++ b/frontend/app/routes/api.config.$type.ts
@@ -16,6 +16,7 @@ import {
   getValidWalletAddress
 } from '~/utils/open-payments.server.js'
 import { APP_BASEPATH } from '~/lib/constants.js'
+import { AWS_PREFIX } from '@shared/defines'
 import { normalizeWalletAddress } from '@shared/utils'
 
 export async function loader({ request, params, context }: LoaderFunctionArgs) {
@@ -45,7 +46,7 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
       await getValidWalletAddress(env, payload.walletAddress as string)
     )
     try {
-      const storageService = new ConfigStorageService(env)
+      const storageService = new ConfigStorageService({ ...env, AWS_PREFIX })
       const fileContentString =
         await storageService.getJson<ConfigVersions>(ownerWalletAddress)
 
@@ -140,7 +141,7 @@ export async function action({ request, params, context }: ActionFunctionArgs) {
   }
 
   ownerWalletAddress = normalizeWalletAddress(walletAddress)
-  const storageService = new ConfigStorageService(env)
+  const storageService = new ConfigStorageService({ ...env, AWS_PREFIX })
   switch (request.method) {
     case 'POST':
       return handleCreate(storageService, formData, ownerWalletAddress)

--- a/shared/defines/index.ts
+++ b/shared/defines/index.ts
@@ -1,9 +1,11 @@
 declare const BUILD_API_URL: string
 declare const BUILD_CDN_URL: string
+declare const BUILD_AWS_PREFIX: string
 
 const DEV_API_URL = 'http://localhost:8787'
 const DEV_CDN_URL = 'http://localhost:5173'
 const DEV_FRONTEND_URL = 'http://localhost:3000/tools/' // contains trailing slash and pathname.
+const DEV_AWS_PREFIX = '20250717-dev'
 
 export const APP_URL = {
   production: 'https://webmonetization.org',
@@ -20,3 +22,12 @@ export const CDN_URL =
   typeof BUILD_CDN_URL === 'string' && BUILD_CDN_URL
     ? BUILD_CDN_URL
     : DEV_CDN_URL
+
+/**
+ * AWS S3 prefix. We can change this per deployment, which helps with data
+ * migration without affecting production server.
+ */
+export const AWS_PREFIX =
+  typeof BUILD_AWS_PREFIX === 'string' && BUILD_AWS_PREFIX
+    ? BUILD_AWS_PREFIX
+    : DEV_AWS_PREFIX


### PR DESCRIPTION
Should help with data migrations per env (https://github.com/interledger/publisher-tools/issues/302). We'll be able to use different `AWS_PREFIX` in staging (migrated data) than production (using prefix from when it was deployed).