### PR TITLE
refactor(api): move `/payment/*` routes to own file

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,18 +1,13 @@
 import { zValidator } from '@hono/zod-validator'
 import { ConfigStorageService } from '@shared/config-storage-service'
-import { APP_URL, AWS_PREFIX } from '@shared/defines'
+import { AWS_PREFIX } from '@shared/defines'
 import type { ConfigVersions } from '@shared/types'
-import { OpenPaymentsService } from './utils/open-payments.js'
-import {
-  PaymentQuoteSchema,
-  PaymentGrantSchema,
-  PaymentFinalizeSchema,
-  WalletAddressParamSchema
-} from './schemas/payment.js'
+import { WalletAddressParamSchema } from './schemas/payment.js'
 import { createHTTPException } from './utils/utils.js'
 import { app } from './app.js'
 
 import './routes/probabilistic-revshare.js'
+import './routes/payment.js'
 
 app.get(
   '/config/:wa/:version?',
@@ -26,86 +21,6 @@ app.get(
       return json(config[version])
     } catch (error) {
       throw createHTTPException(500, 'Config fetch error: ', error)
-    }
-  }
-)
-
-app.post(
-  '/payment/quote',
-  zValidator('json', PaymentQuoteSchema),
-  async ({ req, json, env }) => {
-    try {
-      const { senderWalletAddress, receiverWalletAddress, amount, note } =
-        req.valid('json')
-
-      const openPayments = await OpenPaymentsService.getInstance(env)
-      const result = await openPayments.createPayment({
-        senderWalletAddress,
-        receiverWalletAddress,
-        amount,
-        note
-      })
-
-      return json(result)
-    } catch (error) {
-      throw createHTTPException(500, 'Payment quote creation error: ', error)
-    }
-  }
-)
-
-app.post(
-  '/payment/grant',
-  zValidator('json', PaymentGrantSchema),
-  async ({ req, json, env }) => {
-    try {
-      const { walletAddress, debitAmount, receiveAmount, redirectUrl } =
-        req.valid('json')
-      if (!isAllowedRedirectUrl(redirectUrl)) {
-        throw createHTTPException(400, 'Invalid redirect URL', {})
-      }
-
-      const openPayments = await OpenPaymentsService.getInstance(env)
-      const result = await openPayments.initializePayment({
-        walletAddress,
-        debitAmount,
-        receiveAmount,
-        redirectUrl
-      })
-
-      return json(result)
-    } catch (error) {
-      throw createHTTPException(500, 'Payment grant creation error: ', error)
-    }
-  }
-)
-
-app.post(
-  '/payment/finalize',
-  zValidator('json', PaymentFinalizeSchema),
-  async ({ req, json, env }) => {
-    try {
-      const {
-        walletAddress,
-        pendingGrant,
-        quote,
-        incomingPaymentGrant,
-        interactRef,
-        note
-      } = req.valid('json')
-
-      const openPaymentsService = await OpenPaymentsService.getInstance(env)
-      const result = await openPaymentsService.finishPaymentProcess(
-        walletAddress,
-        pendingGrant,
-        quote,
-        incomingPaymentGrant,
-        interactRef,
-        note
-      )
-
-      return json(result)
-    } catch (error) {
-      throw createHTTPException(500, 'Payment finalization error: ', error)
     }
   }
 )
@@ -130,9 +45,3 @@ app.get('/', (c) => {
 })
 
 export default app
-
-function isAllowedRedirectUrl(redirectUrl: string) {
-  const redirectUrlOrigin = new URL(redirectUrl).origin
-  const ALLOWED_ORIGINS = Object.values(APP_URL)
-  return ALLOWED_ORIGINS.some((origin) => redirectUrlOrigin === origin)
-}

--- a/api/src/routes/payment.ts
+++ b/api/src/routes/payment.ts
@@ -1,0 +1,98 @@
+import { zValidator } from '@hono/zod-validator'
+
+import { APP_URL } from '@shared/defines'
+import { createHTTPException } from '../utils/utils'
+import { OpenPaymentsService } from '../utils/open-payments.js'
+import {
+  PaymentQuoteSchema,
+  PaymentGrantSchema,
+  PaymentFinalizeSchema
+} from '../schemas/payment.js'
+
+import { app } from '../app.js'
+
+app.post(
+  '/payment/quote',
+  zValidator('json', PaymentQuoteSchema),
+  async ({ req, json, env }) => {
+    try {
+      const { senderWalletAddress, receiverWalletAddress, amount, note } =
+        req.valid('json')
+
+      const openPayments = await OpenPaymentsService.getInstance(env)
+      const result = await openPayments.createPayment({
+        senderWalletAddress,
+        receiverWalletAddress,
+        amount,
+        note
+      })
+
+      return json(result)
+    } catch (error) {
+      throw createHTTPException(500, 'Payment quote creation error: ', error)
+    }
+  }
+)
+
+app.post(
+  '/payment/grant',
+  zValidator('json', PaymentGrantSchema),
+  async ({ req, json, env }) => {
+    try {
+      const { walletAddress, debitAmount, receiveAmount, redirectUrl } =
+        req.valid('json')
+      if (!isAllowedRedirectUrl(redirectUrl)) {
+        throw createHTTPException(400, 'Invalid redirect URL', {})
+      }
+
+      const openPayments = await OpenPaymentsService.getInstance(env)
+      const result = await openPayments.initializePayment({
+        walletAddress,
+        debitAmount,
+        receiveAmount,
+        redirectUrl
+      })
+
+      return json(result)
+    } catch (error) {
+      throw createHTTPException(500, 'Payment grant creation error: ', error)
+    }
+  }
+)
+
+app.post(
+  '/payment/finalize',
+  zValidator('json', PaymentFinalizeSchema),
+  async ({ req, json, env }) => {
+    try {
+      const {
+        walletAddress,
+        pendingGrant,
+        quote,
+        incomingPaymentGrant,
+        interactRef,
+        note
+      } = req.valid('json')
+
+      const openPaymentsService = await OpenPaymentsService.getInstance(env)
+      const result = await openPaymentsService.finishPaymentProcess(
+        walletAddress,
+        pendingGrant,
+        quote,
+        incomingPaymentGrant,
+        interactRef,
+        note
+      )
+
+      return json(result)
+    } catch (error) {
+      throw createHTTPException(500, 'Payment finalization error: ', error)
+    }
+  }
+)
+
+function isAllowedRedirectUrl(redirectUrl: string) {
+  const redirectUrlOrigin = new URL(redirectUrl).origin
+  const ALLOWED_ORIGINS = Object.values(APP_URL)
+  return ALLOWED_ORIGINS.some((origin) => redirectUrlOrigin === origin)
+}


### PR DESCRIPTION
Follow up of https://github.com/interledger/publisher-tools/pull/335.