### PR TITLE
feat(shared/config-storage): support using custom AWS S3 endpoint

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -7,8 +7,7 @@ import { serializeError } from './utils/utils.js'
 export type Env = {
   AWS_ACCESS_KEY_ID: string
   AWS_SECRET_ACCESS_KEY: string
-  AWS_REGION: string
-  AWS_BUCKET_NAME: string
+  AWS_S3_ENDPOINT: string
   OP_WALLET_ADDRESS: string
   OP_PRIVATE_KEY: string
   OP_KEY_ID: string

--- a/frontend/app/lib/types.ts
+++ b/frontend/app/lib/types.ts
@@ -64,7 +64,6 @@ declare global {
 
     AWS_ACCESS_KEY_ID: string
     AWS_SECRET_ACCESS_KEY: string
-    AWS_REGION: string
-    AWS_BUCKET_NAME: string
+    AWS_S3_ENDPOINT: string
   }
 }

--- a/shared/config-storage-service/index.ts
+++ b/shared/config-storage-service/index.ts
@@ -3,8 +3,7 @@ import { AwsClient } from 'aws4fetch'
 interface Secrets {
   AWS_ACCESS_KEY_ID: string
   AWS_SECRET_ACCESS_KEY: string
-  AWS_REGION: string
-  AWS_BUCKET_NAME: string
+  AWS_S3_ENDPOINT: string
   AWS_PREFIX: string
 }
 
@@ -17,13 +16,12 @@ export class ConfigStorageService {
   constructor(env: Secrets) {
     ConfigStorageService.instance ??= new AwsClient({
       accessKeyId: env.AWS_ACCESS_KEY_ID,
-      secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
-      region: env.AWS_REGION
+      secretAccessKey: env.AWS_SECRET_ACCESS_KEY
     })
+    this.endpoint = env.AWS_S3_ENDPOINT
 
     this.prefix = env.AWS_PREFIX
     this.client = ConfigStorageService.instance
-    this.endpoint = `https://${env.AWS_BUCKET_NAME}.s3.${env.AWS_REGION}.amazonaws.com`
   }
 
   async getJson<T>(walletAddress: string): Promise<T> {


### PR DESCRIPTION
Part of https://github.com/interledger/publisher-tools/issues/361

I've added the endpoint in existing deployments. It's unused there. Deployments started with this PR will use it. Developers will be a able to add `AWS_S3_ENDPOINT` in `.dev.vars` and our Cloudflare deployments will use one in env/secrets.

Next, I'll explore local S3 setup, as a follow up PR.