### PR TITLE
feat(localenv): use AW3 S3 locally with Cloudflare R2 for dev mode

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,4 +7,5 @@ OP_WALLET_ADDRESS="https://ilp.interledger-test.dev/your-wallet"
 
 AWS_ACCESS_KEY_ID="AWS_KEY_ID"
 AWS_SECRET_ACCESS_KEY="AWS_SECRET_KEY"
-AWS_S3_ENDPOINT="https://bucket-name.s3.bucket-region.amazonaws.com"
+AWS_S3_ENDPOINT="http://localhost:8081" # for dev
+# AWS_S3_ENDPOINT="https://bucket-name.s3.bucket-region.amazonaws.com" # when using AWS

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,20 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "Run Local S3",
+      "type": "shell",
+      "command": "pnpm -C localenv/s3 dev",
+      "hide": true,
+      "runOptions": {
+        "instanceLimit": 1,
+        "instancePolicy": "terminateOldest"
+      },
+      "presentation": {
+        "revealProblems": "onProblem",
+        "group": "localenv"
+      }
+    },
+    {
       "label": "Run CDN",
       "type": "shell",
       "command": "pnpm -C cdn dev",
@@ -64,7 +78,7 @@
         "reveal": "always",
         "showReuseMessage": true
       },
-      "dependsOn": ["Run CDN", "Run API", "Run Editor UI"]
+      "dependsOn": ["Run Local S3", "Run CDN", "Run API", "Run Editor UI"]
     }
   ]
 }

--- a/localenv/s3/README.md
+++ b/localenv/s3/README.md
@@ -1,0 +1,5 @@
+# Emulator for S3 using Cloudflare R2
+
+- Act as a local AWS S3 / Cloudflare R2 public bucket, letting serve objects via GET requests.
+- List objects via `GET /` request.
+- S3 compatible API for `PutObject` via `PUT` requests - minus the authentication.

--- a/localenv/s3/package.json
+++ b/localenv/s3/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "localenv-s3",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "predev": "wrangler types",
+    "dev": "wrangler dev",
+    "prepare": "wrangler types"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.2",
+    "wrangler": "4.40.0"
+  }
+}

--- a/localenv/s3/package.json
+++ b/localenv/s3/package.json
@@ -5,10 +5,11 @@
   "scripts": {
     "predev": "wrangler types",
     "dev": "wrangler dev",
-    "prepare": "wrangler types"
+    "prepare": "wrangler types",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "typescript": "^5.5.2",
+    "typescript": "^5.9.2",
     "wrangler": "4.40.0"
   }
 }

--- a/localenv/s3/tsconfig.json
+++ b/localenv/s3/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "lib": ["es2021"],
+    "module": "es2022",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "isolatedModules": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["./worker-configuration.d.ts"]
+  },
+  "include": ["worker-configuration.d.ts", "worker.ts"]
+}

--- a/localenv/s3/worker.ts
+++ b/localenv/s3/worker.ts
@@ -1,5 +1,5 @@
 export default {
-  async fetch(request, env, ctx): Promise<Response> {
+  async fetch(request, env): Promise<Response> {
     if (request.method === 'PUT') {
       return handlePut(request, env)
     }
@@ -21,7 +21,14 @@ export default {
     if (!res) {
       return new Response('Not Found', { status: 404 })
     }
-    return new Response(res.body)
+    return new Response(res.body, {
+      headers: Object.fromEntries(
+        Object.entries(res.httpMetadata || {}).map(([k, v]) => [
+          k.replace(/([A-Z])/g, '-$1').toLowerCase(),
+          v
+        ])
+      )
+    })
   }
 } satisfies ExportedHandler<Env>
 

--- a/localenv/s3/worker.ts
+++ b/localenv/s3/worker.ts
@@ -1,0 +1,41 @@
+export default {
+  async fetch(request, env, ctx): Promise<Response> {
+    if (request.method === 'PUT') {
+      return handlePut(request, env)
+    }
+
+    const { pathname } = new URL(request.url)
+    if (request.method === 'GET' && pathname === '/') {
+      const keys = await env.STORAGE.list({
+        include: ['customMetadata', 'httpMetadata']
+      })
+      return Response.json(
+        keys.objects.sort(
+          (k1, k2) => k2.uploaded.valueOf() - k1.uploaded.valueOf()
+        )
+      )
+    }
+
+    const key = pathname.slice(1)
+    const res = await env.STORAGE.get(key)
+    if (!res) {
+      return new Response('Not Found', { status: 404 })
+    }
+    return new Response(res.body)
+  }
+} satisfies ExportedHandler<Env>
+
+async function handlePut(request: Request, env: Env) {
+  const { pathname } = new URL(request.url)
+  const key = pathname.slice(1)
+
+  const res = await env.STORAGE.put(key, request.body, {
+    httpMetadata: request.headers,
+    customMetadata: Object.fromEntries(
+      [...request.headers]
+        .filter(([k]) => k.startsWith('x-amz-meta-'))
+        .map(([k, v]) => [k.replace('x-amz-meta-', ''), v])
+    )
+  })
+  return Response.json(res)
+}

--- a/localenv/s3/wrangler.jsonc
+++ b/localenv/s3/wrangler.jsonc
@@ -1,0 +1,15 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "localenv-s3",
+  "main": "worker.ts",
+  "compatibility_date": "2025-09-24",
+  "dev": {
+    "port": 8081
+  },
+  "r2_buckets": [
+    {
+      "binding": "STORAGE",
+      "bucket_name": "wm-tool-configs"
+    }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,6 +292,15 @@ importers:
         specifier: 4.40.0
         version: 4.40.0(@cloudflare/workers-types@4.20250507.0)
 
+  localenv/s3:
+    devDependencies:
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.2
+      wrangler:
+        specifier: 4.40.0
+        version: 4.40.0(@cloudflare/workers-types@4.20250507.0)
+
   shared/config-storage-service:
     dependencies:
       '@shared/utils':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,7 +295,7 @@ importers:
   localenv/s3:
     devDependencies:
       typescript:
-        specifier: ^5.5.2
+        specifier: ^5.9.2
         version: 5.9.2
       wrangler:
         specifier: 4.40.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,4 @@ packages:
   - 'cdn'
   - 'components'
   - 'shared/*'
+  - 'localenv/*'


### PR DESCRIPTION
Closes https://github.com/interledger/publisher-tools/issues/361

- `http://localhost:8081` will act as a AWS endpoint; when run with `pnpm -C localenv/s3 dev`
- Use it as `AWS_S3_ENDPOINT` instead of a `amazonaws.com` URL
   - Use any random string in secret key details - they're unused in dev.
- Update VS Code tasks.json to run this local S3 emulator