### PR TITLE
fix: update WM Logo link to redirect to Web Monetization homepage

### DIFF
--- a/frontend/app/components/redesign/components/Header.tsx
+++ b/frontend/app/components/redesign/components/Header.tsx
@@ -46,8 +46,8 @@ export const Header = () => {
           role="navigation"
           className="relative flex items-center justify-between bg-white shadow-[0px_12px_20px_0px_rgba(0,0,0,0.06)] rounded-lg mx-4 mt-4 h-14 py-1 pl-4 pr-2 md:max-w-7xl md:mx-auto md:px-xl md:py-xs md:mt-0 md:rounded-none md:shadow-none md:bg-transparent md:h-auto md:w-full"
         >
-          <RemixNavLink
-            to="/"
+          <a
+            href="https://webmonetization.org/"
             className="flex items-center focus:outline-none focus-visible:outline-2 focus-visible:outline-nav-link-hover focus-visible:outline-offset-0 rounded-sm"
           >
             <img
@@ -55,7 +55,7 @@ export const Header = () => {
               alt="Web Monetization Logo"
               className="w-8 md:w-11 h-8 md:h-11"
             />
-          </RemixNavLink>
+          </a>
 
           <ul className="hidden md:flex gap-md list-none">
             <NavDropdown title="Tools" />


### PR DESCRIPTION
### Summary
This PR updates the WM Logo link so that it redirects users to the **Web Monetization homepage** (`https://webmonetization.org/`) instead of the current `/tools` path.

### Changes Made
- Replaced `<RemixNavLink to="/" ...>` with a standard `<a href="https://webmonetization.org/" ...>`.
- Ensured the WM Logo (`<img alt="Web Monetization Logo" ... />`) remains consistent across devices and responsive layouts.
- Verified that the logo click now navigates correctly to the homepage.

### Motivation
Clicking the WM Logo should always take the user to the official **Web Monetization homepage**, providing a consistent user experience and aligning with design expectations.

### Related Issue
Closes #179

### Testing
- [x] Verified on local dev environment that the WM Logo redirects correctly.
- [x] Checked on desktop and mobile view for consistent behavior.

---

✅ This is a **good first issue** contribution under Hacktoberfest.  
Please review and let me know if any additional updates are required.
