### PR TITLE
refactor(frontend): remove indirection in banner builder & preview

### DIFF
--- a/frontend/app/components/banner/BannerBuilder.tsx
+++ b/frontend/app/components/banner/BannerBuilder.tsx
@@ -32,9 +32,9 @@ import {
 } from '~/assets/svg'
 import wmLogo from '~/assets/images/wm_logo_animated.svg?url'
 import { useState } from 'react'
+import { toolState } from '~/stores/toolStore'
 
 interface Props {
-  profile: BannerConfig
   onRefresh: (section: 'content' | 'appearance') => void
 }
 
@@ -57,17 +57,18 @@ const config: ContentConfig & AppearanceConfig = {
   fontSizeRange: BANNER_FONT_SIZES
 }
 
-export function BannerBuilder({ profile, onRefresh }: Props) {
+export function BannerBuilder({ onRefresh }: Props) {
   return (
     <>
-      <ContentBuilder profile={profile} onRefresh={onRefresh} />
-      <AppearanceBuilder profile={profile} onRefresh={onRefresh} />
+      <ContentBuilder onRefresh={onRefresh} />
+      <AppearanceBuilder onRefresh={onRefresh} />
     </>
   )
 }
 
-function ContentBuilder({ profile, onRefresh }: Props) {
+function ContentBuilder({ onRefresh }: Props) {
   const { actions: uiActions, state: uiState } = useUI()
+  const profile = toolState.currentConfig as BannerConfig
 
   return (
     <BuilderAccordion
@@ -134,8 +135,9 @@ function ContentBuilder({ profile, onRefresh }: Props) {
   )
 }
 
-function AppearanceBuilder({ profile, onRefresh }: Props) {
+function AppearanceBuilder({ onRefresh }: Props) {
   const { actions: uiActions, state: uiState } = useUI()
+  const profile = toolState.currentConfig as BannerConfig
 
   const { min: minFontSize, max: maxFontSize } = config.fontSizeRange
   const thumbnails = [wmLogo]

--- a/frontend/app/components/banner/BannerBuilder.tsx
+++ b/frontend/app/components/banner/BannerBuilder.tsx
@@ -16,7 +16,6 @@ import {
   CornerRadiusSelector,
   Thumbnail
 } from '@/components'
-import { BuilderForm } from '~/components/builder/BuilderForm'
 import type { ContentConfig } from '~/components/redesign/components/ContentBuilder'
 import type { AppearanceConfig } from '~/components/redesign/components/AppearanceBuilder'
 import BuilderAccordion from '~/components/redesign/components/BuilderAccordion'
@@ -37,7 +36,6 @@ import { useState } from 'react'
 interface Props {
   profile: BannerConfig
   onRefresh: (section: 'content' | 'appearance') => void
-  onComplete: (isComplete: boolean) => void
 }
 
 const config: ContentConfig & AppearanceConfig = {
@@ -59,10 +57,89 @@ const config: ContentConfig & AppearanceConfig = {
   fontSizeRange: BANNER_FONT_SIZES
 }
 
-export function BannerBuilder({ profile, onRefresh, onComplete }: Props) {
+export function BannerBuilder({ profile, onRefresh }: Props) {
+  return (
+    <>
+      <pre className="overflow-auto">{JSON.stringify(profile, null, 2)}</pre>
+      <ContentBuilder profile={profile} onRefresh={onRefresh} />
+      <AppearanceBuilder profile={profile} onRefresh={onRefresh} />
+    </>
+  )
+}
+
+function ContentBuilder({ profile, onRefresh }: Props) {
+  const { actions: uiActions, state: uiState } = useUI()
+
+  return (
+    <BuilderAccordion
+      title="Content"
+      isComplete={uiState.contentComplete}
+      onToggle={(isOpen) => {
+        uiActions.setActiveSection(isOpen ? 'content' : null)
+        if (isOpen) {
+          uiActions.setContentComplete(true)
+        }
+      }}
+      onRefresh={() => onRefresh('content')}
+      onDone={() => {
+        uiActions.setContentComplete(true)
+      }}
+      initialIsOpen={uiState.activeSection === 'content'}
+    >
+      <div className="flex flex-col gap-lg">
+        <TitleInput
+          value={profile.bannerTitleText}
+          onChange={(value) => (profile.bannerTitleText = value)}
+          suggestions={config.suggestedTitles}
+          maxLength={config.titleMaxLength}
+          helpText={config.titleHelpText}
+        />
+
+        <Divider />
+
+        <div className="flex flex-col gap-xs">
+          <h4 className="text-base leading-md font-bold text-text-primary">
+            {config.messageLabel}
+          </h4>
+          <div className="flex gap-lg items-start xl:flex-row flex-col">
+            <div className="flex items-center gap-xs shrink-0">
+              <Checkbox
+                checked={profile.bannerDescriptionVisible}
+                onChange={(visible) => {
+                  profile.bannerDescriptionVisible = visible
+                }}
+                label="Visible"
+              />
+            </div>
+
+            <div className="flex-grow w-full">
+              <TextareaField
+                // ref={messageTextareaRef}
+                defaultValue={profile.bannerDescriptionText}
+                onChange={(e) => {
+                  profile.bannerDescriptionText = e.target.value
+                }}
+                currentLength={profile.bannerDescriptionText.length || 0}
+                maxLength={config.messageMaxLength}
+                showCounter={true}
+                helpText={config.messageHelpText}
+                className="h-[84px]"
+                placeholder={config.messagePlaceholder}
+                disabled={!profile.bannerDescriptionVisible}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </BuilderAccordion>
+  )
+}
+
+function AppearanceBuilder({ profile, onRefresh }: Props) {
+  const { actions: uiActions, state: uiState } = useUI()
+
   const { min: minFontSize, max: maxFontSize } = config.fontSizeRange
   const thumbnails = [wmLogo]
-  const { actions: uiActions, state: uiState } = useUI()
 
   const [selectedThumbnail, setSelectedThumbnail] = useState(0)
 
@@ -80,258 +157,190 @@ export function BannerBuilder({ profile, onRefresh, onComplete }: Props) {
   )
 
   return (
-    <BuilderForm onBuildStepComplete={onComplete}>
-      <pre className="overflow-auto">{JSON.stringify(profile, null, 2)}</pre>
-
-      <BuilderAccordion
-        title="Content"
-        isComplete={uiState.contentComplete}
-        onToggle={(isOpen) => {
-          uiActions.setActiveSection(isOpen ? 'content' : null)
-          if (isOpen) {
-            uiActions.setContentComplete(true)
-          }
-        }}
-        onRefresh={() => onRefresh('content')}
-        onDone={() => {
-          uiActions.setContentComplete(true)
-        }}
-        initialIsOpen={uiState.activeSection === 'content'}
-      >
-        <div className="flex flex-col gap-lg">
-          <TitleInput
-            value={profile.bannerTitleText}
-            onChange={(value) => (profile.bannerTitleText = value)}
-            suggestions={config.suggestedTitles}
-            maxLength={config.titleMaxLength}
-            helpText={config.titleHelpText}
-          />
-
-          <Divider />
-
-          <div className="flex flex-col gap-xs">
-            <h4 className="text-base leading-md font-bold text-text-primary">
-              {config.messageLabel}
-            </h4>
-            <div className="flex gap-lg items-start xl:flex-row flex-col">
-              <div className="flex items-center gap-xs shrink-0">
-                <Checkbox
-                  checked={profile.bannerDescriptionVisible}
-                  onChange={(visible) => {
-                    profile.bannerDescriptionVisible = visible
-                  }}
-                  label="Visible"
-                />
-              </div>
-
-              <div className="flex-grow w-full">
-                <TextareaField
-                  // ref={messageTextareaRef}
-                  defaultValue={profile.bannerDescriptionText}
-                  onChange={(e) => {
-                    profile.bannerDescriptionText = e.target.value
-                  }}
-                  currentLength={profile.bannerDescriptionText.length || 0}
-                  maxLength={config.messageMaxLength}
-                  showCounter={true}
-                  helpText={config.messageHelpText}
-                  className="h-[84px]"
-                  placeholder={config.messagePlaceholder}
-                  disabled={!profile.bannerDescriptionVisible}
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </BuilderAccordion>
-
-      <BuilderAccordion
-        title="Appearance"
-        isComplete={uiState.appearanceComplete}
-        onToggle={(isOpen: boolean) => {
-          uiActions.setActiveSection(isOpen ? 'appearance' : null)
-          if (isOpen) {
-            uiActions.setAppearanceComplete(true)
-          }
-        }}
-        onRefresh={() => onRefresh('appearance')}
-        onDone={() => {
+    <BuilderAccordion
+      title="Appearance"
+      isComplete={uiState.appearanceComplete}
+      onToggle={(isOpen: boolean) => {
+        uiActions.setActiveSection(isOpen ? 'appearance' : null)
+        if (isOpen) {
           uiActions.setAppearanceComplete(true)
-        }}
-        initialIsOpen={uiState.activeSection === 'appearance'}
-      >
-        <div className="flex flex-col gap-xs">
-          <SectionHeader icon={<SVGText className="w-5 h-5" />} label="Text" />
-          <ToolsDropdown
-            label="Font Family"
-            defaultValue={defaultFontIndex.toString()}
-            onChange={(value) => {
-              const fontName = FONT_FAMILY_OPTIONS[parseInt(value)]
-              profile.bannerFontName = fontName
+        }
+      }}
+      onRefresh={() => onRefresh('appearance')}
+      onDone={() => {
+        uiActions.setAppearanceComplete(true)
+      }}
+      initialIsOpen={uiState.activeSection === 'appearance'}
+    >
+      <div className="flex flex-col gap-xs">
+        <SectionHeader icon={<SVGText className="w-5 h-5" />} label="Text" />
+        <ToolsDropdown
+          label="Font Family"
+          defaultValue={defaultFontIndex.toString()}
+          onChange={(value) => {
+            const fontName = FONT_FAMILY_OPTIONS[parseInt(value)]
+            profile.bannerFontName = fontName
+          }}
+          options={FONT_FAMILY_OPTIONS.map((font, index) => ({
+            label: font,
+            value: index.toString()
+          }))}
+        />
+
+        <div className="flex flex-col gap-2xs">
+          <label className="text-xs leading-xs text-silver-700">Size</label>
+          <div className="flex items-center h-12 gap-md">
+            <button
+              className="flex items-center justify-center w-6 h-7 cursor-pointer hover:font-bold"
+              onClick={() => {
+                const newSize = Math.max(
+                  minFontSize,
+                  (profile.bannerFontSize ?? minFontSize) - 1
+                )
+                profile.bannerFontSize = newSize
+              }}
+              aria-label="Decrease font size"
+            >
+              <span className="text-sm leading-sm text-text-primary">A</span>
+            </button>
+
+            <Slider
+              value={profile.bannerFontSize ?? minFontSize}
+              min={minFontSize}
+              max={maxFontSize}
+              onChange={(value) => {
+                console.log('Font size changed to:', value)
+                profile.bannerFontSize = value
+              }}
+            />
+
+            <button
+              className="flex items-center justify-center w-6 h-7 cursor-pointer hover:font-bold"
+              onClick={() => {
+                const newSize = Math.min(
+                  maxFontSize,
+                  (profile.bannerFontSize ?? minFontSize) + 1
+                )
+                profile.bannerFontSize = newSize
+              }}
+            >
+              <span className="text-3xl leading-3xl text-text-primary">A</span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <Divider />
+
+      <div className="flex flex-col gap-xs">
+        <SectionHeader
+          icon={<SVGColorPicker className="w-5 h-5" />}
+          label="Colors"
+        />
+        <BannerColorsSelector
+          backgroundColor={profile.bannerBackgroundColor}
+          textColor={profile.bannerTextColor}
+          onBackgroundColorChange={(color: string) =>
+            (profile.bannerBackgroundColor = color)
+          }
+          onTextColorChange={(color: string) =>
+            (profile.bannerTextColor = color)
+          }
+        />
+      </div>
+      <Divider />
+
+      <div className="flex flex-col gap-xs">
+        <SectionHeader
+          icon={<SVGRoundedCorner className="w-5 h-5" />}
+          label="Container Corner Radius"
+        />
+        <CornerRadiusSelector
+          defaultValue={profile.bannerBorder}
+          onChange={(value) => (profile.bannerBorder = value)}
+        />
+      </div>
+
+      <Divider />
+      <div className="flex flex-col gap-xs">
+        <SectionHeader
+          icon={<SVGHeaderPosition className="w-5 h-5" />}
+          label="Position"
+        />
+        <BannerPositionSelector
+          defaultValue={profile.bannerPosition}
+          onChange={(value) => (profile.bannerPosition = value)}
+        />
+      </div>
+
+      <Divider />
+      <div className="flex flex-col gap-xs">
+        <SectionHeader
+          icon={<SVGAnimation className="w-5 h-5" />}
+          label="Animation"
+        />
+        <div className="flex gap-md xl:flex-row flex-col xl:items-center items-start">
+          <Checkbox
+            checked={profile.bannerSlideAnimation !== SLIDE_ANIMATION.None}
+            onChange={() => {
+              profile.bannerSlideAnimation = isAnimated
+                ? SLIDE_ANIMATION.None
+                : lastSelectedAnimation
             }}
-            options={FONT_FAMILY_OPTIONS.map((font, index) => ({
-              label: font,
-              value: index.toString()
-            }))}
+            label="Animated"
           />
-
-          <div className="flex flex-col gap-2xs">
-            <label className="text-xs leading-xs text-silver-700">Size</label>
-            <div className="flex items-center h-12 gap-md">
-              <button
-                className="flex items-center justify-center w-6 h-7 cursor-pointer hover:font-bold"
-                onClick={() => {
-                  const newSize = Math.max(
-                    minFontSize,
-                    (profile.bannerFontSize ?? minFontSize) - 1
-                  )
-                  profile.bannerFontSize = newSize
-                }}
-                aria-label="Decrease font size"
-              >
-                <span className="text-sm leading-sm text-text-primary">A</span>
-              </button>
-
-              <Slider
-                value={profile.bannerFontSize ?? minFontSize}
-                min={minFontSize}
-                max={maxFontSize}
-                onChange={(value) => {
-                  console.log('Font size changed to:', value)
-                  profile.bannerFontSize = value
-                }}
-              />
-
-              <button
-                className="flex items-center justify-center w-6 h-7 cursor-pointer hover:font-bold"
-                onClick={() => {
-                  const newSize = Math.min(
-                    maxFontSize,
-                    (profile.bannerFontSize ?? minFontSize) + 1
-                  )
-                  profile.bannerFontSize = newSize
-                }}
-              >
-                <span className="text-3xl leading-3xl text-text-primary">
-                  A
-                </span>
-              </button>
-            </div>
-          </div>
-        </div>
-        <Divider />
-
-        <div className="flex flex-col gap-xs">
-          <SectionHeader
-            icon={<SVGColorPicker className="w-5 h-5" />}
-            label="Colors"
-          />
-          <BannerColorsSelector
-            backgroundColor={profile.bannerBackgroundColor}
-            textColor={profile.bannerTextColor}
-            onBackgroundColorChange={(color: string) =>
-              (profile.bannerBackgroundColor = color)
-            }
-            onTextColorChange={(color: string) =>
-              (profile.bannerTextColor = color)
-            }
-          />
-        </div>
-        <Divider />
-
-        <div className="flex flex-col gap-xs">
-          <SectionHeader
-            icon={<SVGRoundedCorner className="w-5 h-5" />}
-            label="Container Corner Radius"
-          />
-          <CornerRadiusSelector
-            defaultValue={profile.bannerBorder}
-            onChange={(value) => (profile.bannerBorder = value)}
-          />
-        </div>
-
-        <Divider />
-        <div className="flex flex-col gap-xs">
-          <SectionHeader
-            icon={<SVGHeaderPosition className="w-5 h-5" />}
-            label="Position"
-          />
-          <BannerPositionSelector
-            defaultValue={profile.bannerPosition}
-            onChange={(value) => (profile.bannerPosition = value)}
-          />
-        </div>
-
-        <Divider />
-        <div className="flex flex-col gap-xs">
-          <SectionHeader
-            icon={<SVGAnimation className="w-5 h-5" />}
-            label="Animation"
-          />
-          <div className="flex gap-md xl:flex-row flex-col xl:items-center items-start">
-            <Checkbox
-              checked={profile.bannerSlideAnimation !== SLIDE_ANIMATION.None}
-              onChange={() => {
-                profile.bannerSlideAnimation = isAnimated
-                  ? SLIDE_ANIMATION.None
+          <div className="flex-1 w-full xl:w-auto">
+            <ToolsDropdown
+              label="Type"
+              disabled={!isAnimated}
+              defaultValue={
+                isAnimated
+                  ? getValidSlideAnimation(profile.bannerSlideAnimation)
                   : lastSelectedAnimation
-              }}
-              label="Animated"
-            />
-            <div className="flex-1 w-full xl:w-auto">
-              <ToolsDropdown
-                label="Type"
-                disabled={!isAnimated}
-                defaultValue={
-                  isAnimated
-                    ? getValidSlideAnimation(profile.bannerSlideAnimation)
-                    : lastSelectedAnimation
-                }
-                options={[
-                  { label: 'Slide', value: SLIDE_ANIMATION.Slide },
-                  { label: 'Fade-in', value: SLIDE_ANIMATION.FadeIn }
-                ]}
-                onChange={(value) => {
-                  const selectedAnimation = value as SlideAnimationType
-                  setLastSelectedAnimation(selectedAnimation)
-                  profile.bannerSlideAnimation = selectedAnimation
-                }}
-              />
-            </div>
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-xs">
-          <Divider />
-          <SectionHeader
-            icon={<SVGThumbnail className="w-5 h-5" />}
-            label="Thumbnail"
-          />
-          <div className="flex gap-md xl:flex-row flex-col xl:items-center items-start">
-            <Checkbox
-              checked={
-                typeof profile.bannerThumbnail === 'undefined' ||
-                !!profile.bannerThumbnail
               }
-              onChange={(visible) => {
-                profile.bannerThumbnail = visible ? 'default' : ''
+              options={[
+                { label: 'Slide', value: SLIDE_ANIMATION.Slide },
+                { label: 'Fade-in', value: SLIDE_ANIMATION.FadeIn }
+              ]}
+              onChange={(value) => {
+                const selectedAnimation = value as SlideAnimationType
+                setLastSelectedAnimation(selectedAnimation)
+                profile.bannerSlideAnimation = selectedAnimation
               }}
-              label="Visible"
             />
-            <div className="flex gap-md">
-              {thumbnails.map((thumbnail, index) => (
-                <Thumbnail
-                  key={index}
-                  isSelected={selectedThumbnail === index}
-                  imageUrl={thumbnail}
-                  onClick={() => setSelectedThumbnail(index)}
-                />
-              ))}
-            </div>
           </div>
         </div>
-      </BuilderAccordion>
-    </BuilderForm>
+      </div>
+
+      <div className="flex flex-col gap-xs">
+        <Divider />
+        <SectionHeader
+          icon={<SVGThumbnail className="w-5 h-5" />}
+          label="Thumbnail"
+        />
+        <div className="flex gap-md xl:flex-row flex-col xl:items-center items-start">
+          <Checkbox
+            checked={
+              typeof profile.bannerThumbnail === 'undefined' ||
+              !!profile.bannerThumbnail
+            }
+            onChange={(visible) => {
+              profile.bannerThumbnail = visible ? 'default' : ''
+            }}
+            label="Visible"
+          />
+          <div className="flex gap-md">
+            {thumbnails.map((thumbnail, index) => (
+              <Thumbnail
+                key={index}
+                isSelected={selectedThumbnail === index}
+                imageUrl={thumbnail}
+                onClick={() => setSelectedThumbnail(index)}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </BuilderAccordion>
   )
 }
 

--- a/frontend/app/components/banner/BannerBuilder.tsx
+++ b/frontend/app/components/banner/BannerBuilder.tsx
@@ -60,7 +60,6 @@ const config: ContentConfig & AppearanceConfig = {
 export function BannerBuilder({ profile, onRefresh }: Props) {
   return (
     <>
-      <pre className="overflow-auto">{JSON.stringify(profile, null, 2)}</pre>
       <ContentBuilder profile={profile} onRefresh={onRefresh} />
       <AppearanceBuilder profile={profile} onRefresh={onRefresh} />
     </>

--- a/frontend/app/components/banner/BannerBuilder.tsx
+++ b/frontend/app/components/banner/BannerBuilder.tsx
@@ -1,0 +1,342 @@
+import {
+  BANNER_FONT_SIZES,
+  FONT_FAMILY_OPTIONS,
+  SLIDE_ANIMATION,
+  type SlideAnimationType,
+  type BannerConfig
+} from '@shared/types'
+import {
+  BannerPositionSelector,
+  BannerColorsSelector,
+  Divider,
+  Checkbox,
+  TextareaField,
+  ToolsDropdown,
+  Slider,
+  CornerRadiusSelector,
+  Thumbnail
+} from '@/components'
+import { BuilderForm } from '~/components/builder/BuilderForm'
+import type { ContentConfig } from '~/components/redesign/components/ContentBuilder'
+import type { AppearanceConfig } from '~/components/redesign/components/AppearanceBuilder'
+import BuilderAccordion from '~/components/redesign/components/BuilderAccordion'
+import { useUI } from '~/stores/uiStore'
+import { TitleInput } from '~/components/redesign/components/builder/TitleInput'
+import { SectionHeader } from '~/components/redesign/components/SectionHeader'
+import {
+  SVGAnimation,
+  SVGColorPicker,
+  SVGHeaderPosition,
+  SVGRoundedCorner,
+  SVGText,
+  SVGThumbnail
+} from '~/assets/svg'
+import wmLogo from '~/assets/images/wm_logo_animated.svg?url'
+import { useState } from 'react'
+
+interface Props {
+  profile: BannerConfig
+  onRefresh: (section: 'content' | 'appearance') => void
+  onComplete: (isComplete: boolean) => void
+}
+
+const config: ContentConfig & AppearanceConfig = {
+  suggestedTitles: [
+    'How to support?',
+    'Fund me',
+    'Pay as you browse',
+    'Easy donate',
+    'Support my work'
+  ],
+  titleHelpText: 'Strong message to help people engage with Web Monetization',
+  titleMaxLength: 60,
+  messageLabel: 'Banner message',
+  messagePlaceholder: 'Enter your banner message...',
+  messageHelpText: 'Strong message to help people engage with Web Monetization',
+  messageMaxLength: 300,
+
+  showThumbnail: true,
+  fontSizeRange: BANNER_FONT_SIZES
+}
+
+export function BannerBuilder({ profile, onRefresh, onComplete }: Props) {
+  const { min: minFontSize, max: maxFontSize } = config.fontSizeRange
+  const thumbnails = [wmLogo]
+  const { actions: uiActions, state: uiState } = useUI()
+
+  const [selectedThumbnail, setSelectedThumbnail] = useState(0)
+
+  const [lastSelectedAnimation, setLastSelectedAnimation] =
+    useState<SlideAnimationType>(() => {
+      const validated = getValidSlideAnimation(profile.bannerSlideAnimation)
+      return validated === SLIDE_ANIMATION.None
+        ? SLIDE_ANIMATION.Slide
+        : validated
+    })
+  const isAnimated = profile.bannerSlideAnimation !== SLIDE_ANIMATION.None
+
+  const defaultFontIndex = FONT_FAMILY_OPTIONS.findIndex(
+    (option) => option === profile.bannerFontName
+  )
+
+  return (
+    <BuilderForm onBuildStepComplete={onComplete}>
+      <pre className="overflow-auto">{JSON.stringify(profile, null, 2)}</pre>
+
+      <BuilderAccordion
+        title="Content"
+        isComplete={uiState.contentComplete}
+        onToggle={(isOpen) => {
+          uiActions.setActiveSection(isOpen ? 'content' : null)
+          if (isOpen) {
+            uiActions.setContentComplete(true)
+          }
+        }}
+        onRefresh={() => onRefresh('content')}
+        onDone={() => {
+          uiActions.setContentComplete(true)
+        }}
+        initialIsOpen={uiState.activeSection === 'content'}
+      >
+        <div className="flex flex-col gap-lg">
+          <TitleInput
+            value={profile.bannerTitleText}
+            onChange={(value) => (profile.bannerTitleText = value)}
+            suggestions={config.suggestedTitles}
+            maxLength={config.titleMaxLength}
+            helpText={config.titleHelpText}
+          />
+
+          <Divider />
+
+          <div className="flex flex-col gap-xs">
+            <h4 className="text-base leading-md font-bold text-text-primary">
+              {config.messageLabel}
+            </h4>
+            <div className="flex gap-lg items-start xl:flex-row flex-col">
+              <div className="flex items-center gap-xs shrink-0">
+                <Checkbox
+                  checked={profile.bannerDescriptionVisible}
+                  onChange={(visible) => {
+                    profile.bannerDescriptionVisible = visible
+                  }}
+                  label="Visible"
+                />
+              </div>
+
+              <div className="flex-grow w-full">
+                <TextareaField
+                  // ref={messageTextareaRef}
+                  defaultValue={profile.bannerDescriptionText}
+                  onChange={(e) => {
+                    profile.bannerDescriptionText = e.target.value
+                  }}
+                  currentLength={profile.bannerDescriptionText.length || 0}
+                  maxLength={config.messageMaxLength}
+                  showCounter={true}
+                  helpText={config.messageHelpText}
+                  className="h-[84px]"
+                  placeholder={config.messagePlaceholder}
+                  disabled={!profile.bannerDescriptionVisible}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </BuilderAccordion>
+
+      <BuilderAccordion
+        title="Appearance"
+        isComplete={uiState.appearanceComplete}
+        onToggle={(isOpen: boolean) => {
+          uiActions.setActiveSection(isOpen ? 'appearance' : null)
+          if (isOpen) {
+            uiActions.setAppearanceComplete(true)
+          }
+        }}
+        onRefresh={() => onRefresh('appearance')}
+        onDone={() => {
+          uiActions.setAppearanceComplete(true)
+        }}
+        initialIsOpen={uiState.activeSection === 'appearance'}
+      >
+        <div className="flex flex-col gap-xs">
+          <SectionHeader icon={<SVGText className="w-5 h-5" />} label="Text" />
+          <ToolsDropdown
+            label="Font Family"
+            defaultValue={defaultFontIndex.toString()}
+            onChange={(value) => {
+              const fontName = FONT_FAMILY_OPTIONS[parseInt(value)]
+              profile.bannerFontName = fontName
+            }}
+            options={FONT_FAMILY_OPTIONS.map((font, index) => ({
+              label: font,
+              value: index.toString()
+            }))}
+          />
+
+          <div className="flex flex-col gap-2xs">
+            <label className="text-xs leading-xs text-silver-700">Size</label>
+            <div className="flex items-center h-12 gap-md">
+              <button
+                className="flex items-center justify-center w-6 h-7 cursor-pointer hover:font-bold"
+                onClick={() => {
+                  const newSize = Math.max(
+                    minFontSize,
+                    (profile.bannerFontSize ?? minFontSize) - 1
+                  )
+                  profile.bannerFontSize = newSize
+                }}
+                aria-label="Decrease font size"
+              >
+                <span className="text-sm leading-sm text-text-primary">A</span>
+              </button>
+
+              <Slider
+                value={profile.bannerFontSize ?? minFontSize}
+                min={minFontSize}
+                max={maxFontSize}
+                onChange={(value) => {
+                  console.log('Font size changed to:', value)
+                  profile.bannerFontSize = value
+                }}
+              />
+
+              <button
+                className="flex items-center justify-center w-6 h-7 cursor-pointer hover:font-bold"
+                onClick={() => {
+                  const newSize = Math.min(
+                    maxFontSize,
+                    (profile.bannerFontSize ?? minFontSize) + 1
+                  )
+                  profile.bannerFontSize = newSize
+                }}
+              >
+                <span className="text-3xl leading-3xl text-text-primary">
+                  A
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+        <Divider />
+
+        <div className="flex flex-col gap-xs">
+          <SectionHeader
+            icon={<SVGColorPicker className="w-5 h-5" />}
+            label="Colors"
+          />
+          <BannerColorsSelector
+            backgroundColor={profile.bannerBackgroundColor}
+            textColor={profile.bannerTextColor}
+            onBackgroundColorChange={(color: string) =>
+              (profile.bannerBackgroundColor = color)
+            }
+            onTextColorChange={(color: string) =>
+              (profile.bannerTextColor = color)
+            }
+          />
+        </div>
+        <Divider />
+
+        <div className="flex flex-col gap-xs">
+          <SectionHeader
+            icon={<SVGRoundedCorner className="w-5 h-5" />}
+            label="Container Corner Radius"
+          />
+          <CornerRadiusSelector
+            defaultValue={profile.bannerBorder}
+            onChange={(value) => (profile.bannerBorder = value)}
+          />
+        </div>
+
+        <Divider />
+        <div className="flex flex-col gap-xs">
+          <SectionHeader
+            icon={<SVGHeaderPosition className="w-5 h-5" />}
+            label="Position"
+          />
+          <BannerPositionSelector
+            defaultValue={profile.bannerPosition}
+            onChange={(value) => (profile.bannerPosition = value)}
+          />
+        </div>
+
+        <Divider />
+        <div className="flex flex-col gap-xs">
+          <SectionHeader
+            icon={<SVGAnimation className="w-5 h-5" />}
+            label="Animation"
+          />
+          <div className="flex gap-md xl:flex-row flex-col xl:items-center items-start">
+            <Checkbox
+              checked={profile.bannerSlideAnimation !== SLIDE_ANIMATION.None}
+              onChange={() => {
+                profile.bannerSlideAnimation = isAnimated
+                  ? SLIDE_ANIMATION.None
+                  : lastSelectedAnimation
+              }}
+              label="Animated"
+            />
+            <div className="flex-1 w-full xl:w-auto">
+              <ToolsDropdown
+                label="Type"
+                disabled={!isAnimated}
+                defaultValue={
+                  isAnimated
+                    ? getValidSlideAnimation(profile.bannerSlideAnimation)
+                    : lastSelectedAnimation
+                }
+                options={[
+                  { label: 'Slide', value: SLIDE_ANIMATION.Slide },
+                  { label: 'Fade-in', value: SLIDE_ANIMATION.FadeIn }
+                ]}
+                onChange={(value) => {
+                  const selectedAnimation = value as SlideAnimationType
+                  setLastSelectedAnimation(selectedAnimation)
+                  profile.bannerSlideAnimation = selectedAnimation
+                }}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-xs">
+          <Divider />
+          <SectionHeader
+            icon={<SVGThumbnail className="w-5 h-5" />}
+            label="Thumbnail"
+          />
+          <div className="flex gap-md xl:flex-row flex-col xl:items-center items-start">
+            <Checkbox
+              checked={
+                typeof profile.bannerThumbnail === 'undefined' ||
+                !!profile.bannerThumbnail
+              }
+              onChange={(visible) => {
+                profile.bannerThumbnail = visible ? 'default' : ''
+              }}
+              label="Visible"
+            />
+            <div className="flex gap-md">
+              {thumbnails.map((thumbnail, index) => (
+                <Thumbnail
+                  key={index}
+                  isSelected={selectedThumbnail === index}
+                  imageUrl={thumbnail}
+                  onClick={() => setSelectedThumbnail(index)}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </BuilderAccordion>
+    </BuilderForm>
+  )
+}
+
+function getValidSlideAnimation(value: unknown): SlideAnimationType {
+  return typeof value === 'string' && value in SLIDE_ANIMATION
+    ? (value as SlideAnimationType)
+    : SLIDE_ANIMATION.Slide
+}

--- a/frontend/app/components/banner/BannerPreview.tsx
+++ b/frontend/app/components/banner/BannerPreview.tsx
@@ -1,0 +1,103 @@
+import React, {
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
+import type { BannerConfig, Banner as BannerElement } from '@tools/components'
+import type { BannerConfig as BannerStoredConfig } from '@shared/types'
+
+export interface BannerHandle {
+  triggerPreview: () => void
+}
+
+interface Props {
+  profile: BannerStoredConfig
+  cdnUrl: string
+  ref?: React.Ref<BannerHandle>
+}
+
+export const BannerPreview = ({
+  profile,
+  cdnUrl,
+  ref
+}: React.PropsWithChildren<Props>) => {
+  const [isLoaded, setIsLoaded] = useState(false)
+  const bannerContainerRef = useRef<HTMLDivElement>(null)
+  const bannerElementRef = useRef<BannerElement | null>(null)
+
+  useImperativeHandle(ref, () => ({
+    triggerPreview: () => {
+      if (bannerElementRef.current) {
+        bannerElementRef.current.previewAnimation()
+      }
+    }
+  }))
+
+  useEffect(() => {
+    const loadBannerElement = async () => {
+      if (!customElements.get('wm-banner')) {
+        // dynamic import - ensure component only runs on the client side and not on SSR
+        const { Banner } = await import('@tools/components/banner')
+        if (!customElements.get('wm-banner')) {
+          customElements.define('wm-banner', Banner)
+        }
+      }
+      setIsLoaded(true)
+    }
+
+    loadBannerElement()
+  }, [])
+
+  const bannerConfig = useMemo(() => {
+    return {
+      cdnUrl,
+      bannerTitleText: profile.bannerTitleText,
+      bannerDescriptionText: profile.bannerDescriptionText,
+      isBannerDescriptionVisible: profile.bannerDescriptionVisible,
+      bannerPosition: profile.bannerPosition,
+      bannerBorderRadius: profile.bannerBorder,
+      bannerSlideAnimation: profile.bannerSlideAnimation,
+      bannerThumbnail: profile.bannerThumbnail,
+      theme: {
+        backgroundColor: profile.bannerBackgroundColor,
+        textColor: profile.bannerTextColor,
+        fontSize: profile.bannerFontSize,
+        fontFamily: profile.bannerFontName
+      }
+    } as BannerConfig
+  }, [profile, cdnUrl])
+
+  useEffect(() => {
+    if (bannerContainerRef.current && isLoaded) {
+      if (bannerElementRef.current) {
+        bannerElementRef.current.config = bannerConfig
+        return
+      }
+
+      const bannerElement = document.createElement('wm-banner') as BannerElement
+      bannerElement.config = bannerConfig
+      bannerElementRef.current = bannerElement
+
+      bannerContainerRef.current.appendChild(bannerElement)
+    }
+  }, [bannerConfig, isLoaded])
+
+  if (!isLoaded) {
+    return <div>Loading...</div>
+  }
+
+  return (
+    <div
+      ref={bannerContainerRef}
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%'
+      }}
+    />
+  )
+}
+
+BannerPreview.displayName = 'BannerPreview'

--- a/frontend/app/components/builder/BuilderForm.tsx
+++ b/frontend/app/components/builder/BuilderForm.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect } from 'react'
+import { BuilderPresetTabs } from '@/components'
+import { toolState, toolActions, type StableKey } from '~/stores/toolStore'
+import { useUI } from '~/stores/uiStore'
+import { useSnapshot } from 'valtio'
+
+interface Props {
+  onBuildStepComplete: (isComplete: boolean) => void
+}
+
+export function BuilderForm({
+  onBuildStepComplete,
+  children
+}: React.PropsWithChildren<Props>) {
+  const snap = useSnapshot(toolState)
+  const { state: uiState } = useUI()
+
+  useEffect(() => {
+    const bothComplete = uiState.contentComplete && uiState.appearanceComplete
+    if (onBuildStepComplete) {
+      onBuildStepComplete(bothComplete)
+    }
+  }, [uiState.contentComplete, uiState.appearanceComplete, onBuildStepComplete])
+
+  const handleTabSelect = (stableKey: StableKey) => {
+    toolActions.selectVersion(stableKey)
+  }
+
+  const getLatestTabOptions = () => {
+    return toolActions.versionOptions.map(({ stableKey: id }) => ({
+      id,
+      label: toolState.configurations[id].versionName,
+      isDirty: toolState.modifiedVersions.includes(id)
+    }))
+  }
+  const [tabOptions, setTabOptions] = React.useState(getLatestTabOptions)
+  const handleTabLabelChange = (stableKey: StableKey, newLabel: string) => {
+    toolActions.updateVersionLabel(stableKey, newLabel)
+    setTabOptions(() => getLatestTabOptions())
+  }
+
+  useEffect(() => {
+    setTabOptions(() => getLatestTabOptions())
+  }, [
+    toolState.isSubmitting,
+    toolState.currentConfig.walletAddress,
+    toolState.currentConfig.versionName
+  ])
+
+  return (
+    <div className="flex flex-col mt-4">
+      <BuilderPresetTabs
+        idPrefix="presets"
+        options={tabOptions}
+        selectedId={snap.activeVersion}
+        onChange={handleTabSelect}
+        onRename={handleTabLabelChange}
+      >
+        {children}
+      </BuilderPresetTabs>
+    </div>
+  )
+}

--- a/frontend/app/components/builder/BuilderForm.tsx
+++ b/frontend/app/components/builder/BuilderForm.tsx
@@ -5,10 +5,12 @@ import { useUI } from '~/stores/uiStore'
 import { useSnapshot } from 'valtio'
 
 interface Props {
+  onProfileChange: (profile: StableKey) => void
   onBuildStepComplete: (isComplete: boolean) => void
 }
 
 export function BuilderForm({
+  onProfileChange,
   onBuildStepComplete,
   children
 }: React.PropsWithChildren<Props>) {
@@ -24,6 +26,7 @@ export function BuilderForm({
 
   const handleTabSelect = (stableKey: StableKey) => {
     toolActions.selectVersion(stableKey)
+    onProfileChange(stableKey)
   }
 
   const getLatestTabOptions = () => {

--- a/frontend/app/components/builder/BuilderTabs.tsx
+++ b/frontend/app/components/builder/BuilderTabs.tsx
@@ -5,12 +5,10 @@ import { useUI } from '~/stores/uiStore'
 import { useSnapshot } from 'valtio'
 
 interface Props {
-  onProfileChange: (profile: StableKey) => void
   onBuildStepComplete: (isComplete: boolean) => void
 }
 
 export function BuilderTabs({
-  onProfileChange,
   onBuildStepComplete,
   children
 }: React.PropsWithChildren<Props>) {
@@ -26,7 +24,6 @@ export function BuilderTabs({
 
   const handleTabSelect = (stableKey: StableKey) => {
     toolActions.selectVersion(stableKey)
-    onProfileChange(stableKey)
   }
 
   const getLatestTabOptions = () => {

--- a/frontend/app/components/builder/BuilderTabs.tsx
+++ b/frontend/app/components/builder/BuilderTabs.tsx
@@ -9,7 +9,7 @@ interface Props {
   onBuildStepComplete: (isComplete: boolean) => void
 }
 
-export function BuilderForm({
+export function BuilderTabs({
   onProfileChange,
   onBuildStepComplete,
   children

--- a/frontend/app/routes/banner.tsx
+++ b/frontend/app/routes/banner.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
-import { proxy, useSnapshot } from 'valtio'
+import { useSnapshot } from 'valtio'
 import { useLoaderData, useNavigate } from '@remix-run/react'
 import { useUI } from '~/stores/uiStore'
 import { usePathTracker } from '~/hooks/usePathTracker'
@@ -38,7 +38,6 @@ import {
 import { commitSession, getSession } from '~/utils/session.server.js'
 import { useBodyClass } from '~/hooks/useBodyClass'
 import { SVGSpinner } from '@/assets'
-import type { BannerConfig } from '@shared/types'
 
 export const meta: MetaFunction = () => {
   return [
@@ -79,9 +78,6 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
 
 export default function Banner() {
   const snap = useSnapshot(toolState)
-  const [profile, setProfile] = useState<BannerConfig>(
-    proxy(snap.currentConfig)
-  )
   const { actions: uiActions } = useUI()
   const navigate = useNavigate()
   const [isLoading, setIsLoading] = useState(false)
@@ -236,17 +232,9 @@ export default function Banner() {
                           isComplete ? 'filled' : 'unfilled'
                         )
                       }}
-                      onProfileChange={(profileId) => {
-                        const profile = Object.fromEntries(
-                          Object.entries(
-                            toolState.configurations[profileId]
-                          ).filter(([key]) => key.startsWith('banner'))
-                        ) as BannerConfig
-                        setProfile(proxy(profile))
-                      }}
                     >
                       <BannerBuilder
-                        profile={profile}
+                        profile={snap.currentConfig}
                         onRefresh={handleRefresh}
                       />
                     </BuilderTabs>
@@ -303,7 +291,7 @@ export default function Banner() {
                     <BuilderBackground onPreviewClick={handlePreviewClick}>
                       <BannerPreview
                         ref={bannerRef}
-                        profile={profile}
+                        profile={snap.currentConfig}
                         cdnUrl={snap.cdnUrl}
                       />
                     </BuilderBackground>

--- a/frontend/app/routes/banner.tsx
+++ b/frontend/app/routes/banner.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useEffect,
-  useState,
-  useRef,
-  useMemo,
-  useImperativeHandle
-} from 'react'
+import { useEffect, useState, useRef } from 'react'
 import { useSnapshot } from 'valtio'
 import { useLoaderData, useNavigate } from '@remix-run/react'
 import { useUI } from '~/stores/uiStore'
@@ -17,7 +11,6 @@ import {
 import {
   HeadingCore,
   ToolsWalletAddress,
-  BuilderForm,
   BuilderBackground,
   ToolsSecondaryButton,
   ToolsPrimaryButton,
@@ -26,10 +19,13 @@ import {
   WalletOwnershipModal,
   OverridePresetModal,
   StepsIndicator,
-  MobileStepsIndicator,
-  BannerPositionSelector,
-  BannerColorsSelector
+  MobileStepsIndicator
 } from '@/components'
+import { BannerBuilder } from '~/components/banner/BannerBuilder'
+import {
+  BannerPreview,
+  type BannerHandle
+} from '~/components/banner/BannerPreview'
 import {
   toolState,
   toolActions,
@@ -41,22 +37,6 @@ import {
 import { commitSession, getSession } from '~/utils/session.server.js'
 import { useBodyClass } from '~/hooks/useBodyClass'
 import { SVGSpinner } from '@/assets'
-import type { BannerConfig, Banner as BannerComponent } from '@tools/components'
-import type {
-  ContentConfig,
-  ToolContent
-} from '~/components/redesign/components/ContentBuilder'
-import type {
-  AppearanceConfig,
-  BannerToolAppearance
-} from '~/components/redesign/components/AppearanceBuilder'
-import { BANNER_FONT_SIZES } from '@shared/types'
-import type {
-  BannerPositionKey,
-  CornerType,
-  FontFamilyKey,
-  SlideAnimationType
-} from '@shared/types'
 
 export const meta: MetaFunction = () => {
   return [
@@ -95,113 +75,6 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
   )
 }
 
-interface BannerHandle {
-  triggerPreview: () => void
-}
-
-const BannerPreview = React.forwardRef<BannerHandle>((props, ref) => {
-  const snap = useSnapshot(toolState)
-  const [isLoaded, setIsLoaded] = useState(false)
-  const bannerContainerRef = useRef<HTMLDivElement>(null)
-  const bannerElementRef = useRef<BannerComponent | null>(null)
-
-  useImperativeHandle(ref, () => ({
-    triggerPreview: () => {
-      if (bannerElementRef.current) {
-        bannerElementRef.current.previewAnimation()
-      }
-    }
-  }))
-
-  useEffect(() => {
-    const loadBannerComponent = async () => {
-      if (!customElements.get('wm-banner')) {
-        // dynamic import - ensure component only runs on the client side and not on SSR
-        const { Banner } = await import('@tools/components/banner')
-        customElements.define('wm-banner', Banner)
-      }
-      setIsLoaded(true)
-    }
-
-    loadBannerComponent()
-  }, [])
-
-  const bannerConfig = useMemo(
-    () =>
-      ({
-        cdnUrl: snap.cdnUrl,
-        bannerTitleText: snap.currentConfig?.bannerTitleText,
-        bannerDescriptionText: snap.currentConfig?.bannerDescriptionText,
-        isBannerDescriptionVisible:
-          snap.currentConfig?.bannerDescriptionVisible,
-        bannerPosition: snap.currentConfig?.bannerPosition,
-        bannerBorderRadius: snap.currentConfig?.bannerBorder,
-        bannerSlideAnimation: snap.currentConfig?.bannerSlideAnimation,
-        bannerThumbnail: snap.currentConfig?.bannerThumbnail,
-        theme: {
-          backgroundColor: snap.currentConfig?.bannerBackgroundColor,
-          textColor: snap.currentConfig?.bannerTextColor,
-          fontSize: snap.currentConfig?.bannerFontSize,
-          fontFamily: snap.currentConfig?.bannerFontName
-        }
-      }) as BannerConfig,
-    [snap.currentConfig]
-  )
-
-  useEffect(() => {
-    if (bannerContainerRef.current && isLoaded) {
-      if (bannerElementRef.current) {
-        bannerElementRef.current.config = bannerConfig
-        return
-      }
-
-      const bannerElement = document.createElement(
-        'wm-banner'
-      ) as BannerComponent
-      bannerElement.config = bannerConfig
-      bannerElementRef.current = bannerElement
-
-      bannerContainerRef.current.appendChild(bannerElement)
-    }
-  }, [bannerConfig, isLoaded])
-
-  if (!isLoaded) {
-    return <div>Loading...</div>
-  }
-
-  return (
-    <div
-      ref={bannerContainerRef}
-      style={{
-        position: 'relative',
-        width: '100%',
-        height: '100%'
-      }}
-    />
-  )
-})
-
-BannerPreview.displayName = 'BannerPreview'
-
-const config: ContentConfig | AppearanceConfig = {
-  suggestedTitles: [
-    'How to support?',
-    'Fund me',
-    'Pay as you browse',
-    'Easy donate',
-    'Support my work'
-  ],
-  titleHelpText: 'Strong message to help people engage with Web Monetization',
-  titleMaxLength: 60,
-  messageLabel: 'Banner message',
-  messagePlaceholder: 'Enter your banner message...',
-  messageHelpText: 'Strong message to help people engage with Web Monetization',
-  messageMaxLength: 300,
-
-  showThumbnail: true,
-  fontSizeRange: BANNER_FONT_SIZES
-}
-
 export default function Banner() {
   const snap = useSnapshot(toolState)
   const { actions: uiActions } = useUI()
@@ -213,51 +86,6 @@ export default function Banner() {
   const { grantResponse, isGrantAccepted, isGrantResponse, OP_WALLET_ADDRESS } =
     useLoaderData<typeof loader>()
   usePathTracker()
-
-  const profile: ToolContent | BannerToolAppearance = {
-    currentTitle: snap.currentConfig?.bannerTitleText,
-    currentMessage: snap.currentConfig?.bannerDescriptionText,
-    isDescriptionVisible: snap.currentConfig?.bannerDescriptionVisible ?? true,
-    onTitleChange: (title: string) =>
-      toolActions.setToolConfig({ bannerTitleText: title }),
-    onMessageChange: (message: string) =>
-      toolActions.setToolConfig({ bannerDescriptionText: message }),
-    onSuggestedTitleClick: (title: string) =>
-      toolActions.setToolConfig({ bannerTitleText: title.replace(/"/g, '') }),
-    onDescriptionVisibilityChange: (visible: boolean) =>
-      toolActions.setToolConfig({
-        bannerDescriptionVisible: visible
-      }),
-
-    fontName: snap.currentConfig?.bannerFontName,
-    fontSize: snap.currentConfig?.bannerFontSize ?? BANNER_FONT_SIZES.default,
-    backgroundColor: snap.currentConfig?.bannerBackgroundColor,
-    textColor: snap.currentConfig?.bannerTextColor,
-    borderRadius: snap.currentConfig?.bannerBorder,
-    position: snap.currentConfig?.bannerPosition,
-    slideAnimation: snap.currentConfig?.bannerSlideAnimation,
-    thumbnail: snap.currentConfig?.bannerThumbnail ?? 'default',
-
-    onFontNameChange: (fontName: FontFamilyKey) =>
-      toolActions.setToolConfig({ bannerFontName: fontName }),
-    onFontSizeChange: (fontSize: number) =>
-      toolActions.setToolConfig({ bannerFontSize: fontSize }),
-    onBackgroundColorChange: (color: string) =>
-      toolActions.setToolConfig({ bannerBackgroundColor: color }),
-    onTextColorChange: (color: string) =>
-      toolActions.setToolConfig({ bannerTextColor: color }),
-    onBorderChange: (border: CornerType) =>
-      toolActions.setToolConfig({ bannerBorder: border }),
-    onPositionChange: (position: BannerPositionKey) =>
-      toolActions.setToolConfig({ bannerPosition: position }),
-    onSlideAnimationChange: (animation: SlideAnimationType) =>
-      toolActions.setToolConfig({ bannerSlideAnimation: animation }),
-    onThumbnailVisibilityChange: (visible: boolean) => {
-      toolActions.setToolConfig({ bannerThumbnail: visible ? 'default' : '' })
-    },
-
-    showAnimation: true
-  }
 
   useBodyClass('has-fixed-action-bar')
 
@@ -342,6 +170,7 @@ export default function Banner() {
     const { content, appearance } = splitConfigProperties(savedConfig)
     toolActions.setToolConfig(section === 'content' ? content : appearance)
   }
+
   return (
     <div className="bg-interface-bg-main w-full">
       <div className="flex flex-col items-center pt-[60px] md:pt-3xl">
@@ -396,41 +225,14 @@ export default function Banner() {
                       status={snap.buildStep}
                     />
 
-                    <BuilderForm
-                      profile={profile}
-                      config={config}
-                      onBuildStepComplete={(isComplete) =>
+                    <BannerBuilder
+                      profile={snap.currentConfig}
+                      onRefresh={handleRefresh}
+                      onComplete={(isComplete) => {
                         toolActions.setBuildCompleteStep(
                           isComplete ? 'filled' : 'unfilled'
                         )
-                      }
-                      onRefresh={handleRefresh}
-                      positionSelector={
-                        <BannerPositionSelector
-                          defaultValue={snap.currentConfig?.bannerPosition}
-                          onChange={(value) =>
-                            toolActions.setToolConfig({ bannerPosition: value })
-                          }
-                        />
-                      }
-                      colorsSelector={
-                        <BannerColorsSelector
-                          backgroundColor={
-                            snap.currentConfig?.bannerBackgroundColor
-                          }
-                          textColor={snap.currentConfig?.bannerTextColor}
-                          onBackgroundColorChange={(color: string) =>
-                            toolActions.setToolConfig({
-                              bannerBackgroundColor: color
-                            })
-                          }
-                          onTextColorChange={(color: string) =>
-                            toolActions.setToolConfig({
-                              bannerTextColor: color
-                            })
-                          }
-                        />
-                      }
+                      }}
                     />
 
                     <div
@@ -483,7 +285,11 @@ export default function Banner() {
                     className="w-full mx-auto xl:mx-0 xl:sticky xl:top-md xl:self-start xl:flex-shrink-0 xl:w-[504px] h-fit"
                   >
                     <BuilderBackground onPreviewClick={handlePreviewClick}>
-                      <BannerPreview ref={bannerRef} />
+                      <BannerPreview
+                        ref={bannerRef}
+                        profile={snap.currentConfig}
+                        cdnUrl={snap.cdnUrl}
+                      />
                     </BuilderBackground>
                   </div>
                 </div>

--- a/frontend/app/routes/banner.tsx
+++ b/frontend/app/routes/banner.tsx
@@ -21,7 +21,7 @@ import {
   StepsIndicator,
   MobileStepsIndicator
 } from '@/components'
-import { BuilderForm } from '~/components/builder/BuilderForm'
+import { BuilderTabs } from '~/components/builder/BuilderTabs'
 import { BannerBuilder } from '~/components/banner/BannerBuilder'
 import {
   BannerPreview,
@@ -230,7 +230,7 @@ export default function Banner() {
                       status={snap.buildStep}
                     />
 
-                    <BuilderForm
+                    <BuilderTabs
                       onBuildStepComplete={(isComplete) => {
                         toolActions.setBuildCompleteStep(
                           isComplete ? 'filled' : 'unfilled'
@@ -249,7 +249,7 @@ export default function Banner() {
                         profile={profile}
                         onRefresh={handleRefresh}
                       />
-                    </BuilderForm>
+                    </BuilderTabs>
 
                     <div
                       id="builder-actions"

--- a/frontend/app/routes/banner.tsx
+++ b/frontend/app/routes/banner.tsx
@@ -233,10 +233,7 @@ export default function Banner() {
                         )
                       }}
                     >
-                      <BannerBuilder
-                        profile={snap.currentConfig}
-                        onRefresh={handleRefresh}
-                      />
+                      <BannerBuilder onRefresh={handleRefresh} />
                     </BuilderTabs>
 
                     <div


### PR DESCRIPTION
Helps with https://github.com/interledger/publisher-tools/issues/307, https://github.com/interledger/publisher-tools/issues/302.

- Create `BannerBuilder` instead of using `ContentBuilder` and `AppearanceBuilder`
   - Use `BannerConfig` directly instead of converting config specific to `ContentBuilder` and `AppearanceBuilder`
   - Now, stored config maps editor config one-to-one; and we don't need actions to modify config.
- Refactor: Extract `BannerPreview` out of `banner.tsx`
- Turn `BuilderForm` to just `BuilderTabs` - it'll only manage "tabs" (profiles)

Notes to reviewer: most of it just moving code.