### PR TITLE
fix(TitleInput): ensure value is modified on load

### DIFF
--- a/frontend/app/components/redesign/components/PillRadioListItem.tsx
+++ b/frontend/app/components/redesign/components/PillRadioListItem.tsx
@@ -1,21 +1,23 @@
 import React from 'react'
 import { cx } from 'class-variance-authority'
 
-interface PillRadioListItemProps {
+interface PillRadioListItemProps<T extends string> {
   radioGroup: string
   selected: boolean
-  value: string
+  value: T
+  onSelect: () => void
   children: React.ReactNode
   size?: 'sm' | 'md'
 }
 
-export const PillRadioListItem: React.FC<PillRadioListItemProps> = ({
+export const PillRadioListItem = <T extends string>({
   radioGroup,
   value,
+  onSelect,
   children,
   selected,
   size = 'md'
-}) => {
+}: PillRadioListItemProps<T>) => {
   const sizeClasses = {
     sm: 'px-2 py-1 text-xs leading-xs',
     md: 'px-sm py-2xs text-sm leading-sm'
@@ -64,6 +66,7 @@ export const PillRadioListItem: React.FC<PillRadioListItemProps> = ({
         defaultChecked={selected}
         value={value}
         className="sr-only"
+        onClick={onSelect}
       />
     </label>
   )

--- a/frontend/app/components/redesign/components/builder/TitleInput.tsx
+++ b/frontend/app/components/redesign/components/builder/TitleInput.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react'
 import Divider from '../Divider'
 import { InputField } from '../InputField'
 import PillRadioListItem from '../PillRadioListItem'
@@ -54,19 +55,14 @@ function SuggestedTitles({
       >
         Suggested title
       </div>
-      <div
-        className="flex flex-wrap gap-xs group"
-        onChange={(ev) => {
-          const input = ev.target as HTMLInputElement
-          onChange(input.value)
-        }}
-      >
+      <div className="flex flex-wrap gap-xs group">
         {suggestions.map((title) => (
           <PillRadioListItem
             key={title}
             value={title}
             selected={value === title}
             radioGroup="suggested-title"
+            onSelect={() => onChange(title)}
           >
             {title}
           </PillRadioListItem>
@@ -83,17 +79,23 @@ function CustomTitle({
   maxLength,
   helpText
 }: Omit<Props, 'suggestions'> & { placeholder: string }) {
+  const ref = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.value = value
+    }
+  }, [value])
+
   return (
     <div className="flex flex-col gap-xs">
       <h4 className="text-base leading-md font-bold text-text-primary">
         Custom title
       </h4>
       <InputField
-        value={value}
+        defaultValue={value}
+        onChange={(e) => onChange(e.target.value.trim())}
+        ref={ref}
         placeholder={placeholder}
-        onChange={(e) => {
-          onChange(e.target.value.trim())
-        }}
         showCounter={true}
         currentLength={value.length}
         maxLength={maxLength}


### PR DESCRIPTION
And some fixes to `SuggestedTitles` handling (and improved TypeScript).
In staging, if you select a suggested title, then edit it as custom title, then you cannot again select the previously chosen suggested title - you only only pick others.

As seen in https://github.com/interledger/publisher-tools/pull/395#discussion_r2412252971, we do need the `ref.current.value = value` hack for now, until we figure what causes entire builder to re-render when a prop changes.

To be merged before https://github.com/interledger/publisher-tools/pull/395.