### PR TITLE
fix(app/widget): open full preview by default

### DIFF
--- a/frontend/app/components/widget/WidgetPreview.tsx
+++ b/frontend/app/components/widget/WidgetPreview.tsx
@@ -62,6 +62,7 @@ export const WidgetPreview = ({
       const widget = widgetRef.current
       widget.config = widgetConfig
       widget.isPreview = true
+      widget.isOpen = true
     }
   }, [widgetConfig, isLoaded])
 


### PR DESCRIPTION
Sets preview open to default when page is loaded

Discussed via [Slack](https://interledgerfoundation.slack.com/archives/C08FYR2GSPP/p1760014541066119)

