### PR TITLE
fix(api/payments): use full resourceServer instead of just origin

### DIFF
--- a/api/src/utils/open-payments.ts
+++ b/api/src/utils/open-payments.ts
@@ -232,11 +232,9 @@ export class OpenPaymentsService {
       throw new Error('Expected finalized grant.')
     }
 
-    const url = new URL(walletAddress.resourceServer).origin
-
     const outgoingPayment = await this.client!.outgoingPayment.create(
       {
-        url: url,
+        url: walletAddress.resourceServer,
         accessToken: continuation.access_token.value
       },
       {


### PR DESCRIPTION
With multi-tenancy, resourceServer can have URL more than just origin.