### PR TITLE
fix(TitleInput): use `<label>` instead of `<h4>` for a11y

### DIFF
--- a/frontend/app/components/redesign/components/builder/TitleInput.tsx
+++ b/frontend/app/components/redesign/components/builder/TitleInput.tsx
@@ -80,12 +80,17 @@ function CustomTitle({
   helpText
 }: Omit<Props, 'suggestions'> & { placeholder: string }) {
   const ref = useRef<HTMLInputElement>(null)
+  const id = 'custom-title-input'
   return (
     <div className="flex flex-col gap-xs">
-      <h4 className="text-base leading-md font-bold text-text-primary">
+      <label
+        htmlFor={id}
+        className="text-base leading-md font-bold text-text-primary"
+      >
         Custom title
-      </h4>
+      </label>
       <InputField
+        id={id}
         value={value}
         onChange={(e) => onChange(e.target.value.trim())}
         ref={ref}


### PR DESCRIPTION
The change replaces the heading with a semantic label and associates it with the input field using the `htmlFor` and `id` attributes, which helps screen readers and improves form accessibility.

Apart of ongoing changes for #218 