### PR TITLE
fix(ToolsWalletAddress): Fix wrong text

### DIFF
--- a/frontend/app/components/redesign/components/ToolsWalletAddress.tsx
+++ b/frontend/app/components/redesign/components/ToolsWalletAddress.tsx
@@ -15,7 +15,11 @@ import {
   toWalletAddressUrl
 } from '@shared/utils'
 
-export const ToolsWalletAddress = () => {
+interface ToolsWalletAddressProps {
+  toolName: 'drawer banner' | 'payment widget'
+}
+
+export const ToolsWalletAddress = ({ toolName }: ToolsWalletAddressProps) => {
   const snap = useSnapshot(toolState)
   const uiActions = useUIActions()
   const [error, setError] = useState<ElementErrors>()
@@ -126,8 +130,8 @@ export const ToolsWalletAddress = () => {
     if (!snap.hasRemoteConfigs) {
       return (
         <p className="w-full text-style-small-standard !text-text-success">
-          There are no custom edits for the drawer banner correlated to this
-          wallet address but you can start customizing when you want.
+          There are no custom edits for the {toolName} correlated to this wallet
+          address but you can start customizing when you want.
         </p>
       )
     }
@@ -136,7 +140,7 @@ export const ToolsWalletAddress = () => {
       <p className="w-full text-style-small-standard !text-text-success">
         We&apos;ve loaded your configuration.
         <br />
-        Feel free to keep customizing your banner to fit your style.
+        Feel free to keep customizing your {toolName} to fit your style.
       </p>
     )
   }

--- a/frontend/app/routes/banner.tsx
+++ b/frontend/app/routes/banner.tsx
@@ -213,7 +213,7 @@ export default function Banner() {
                     label="Connect"
                     status={snap.walletConnectStep}
                   />
-                  <ToolsWalletAddress />
+                  <ToolsWalletAddress toolName="drawer banner" />
                 </div>
 
                 <div className="flex flex-col xl:flex-row gap-2xl">

--- a/frontend/app/routes/widget.tsx
+++ b/frontend/app/routes/widget.tsx
@@ -204,7 +204,7 @@ export default function Widget() {
                     label="Connect"
                     status={snap.walletConnectStep}
                   />
-                  <ToolsWalletAddress />
+                  <ToolsWalletAddress toolName="payment widget" />
                 </div>
 
                 <div className="flex flex-col xl:flex-row gap-2xl">


### PR DESCRIPTION
Closes #446 
* Changed the `ToolsWalletAddress` component to accept a `toolName` prop
* Updated the usage of `ToolsWalletAddress` in `banner.tsx` and `widget.tsx` to pass the correct `toolName` value