### PR TITLE
fix(revshare): update import url placeholder and instructions

### DIFF
--- a/frontend/app/components/redesign/components/revshare/ImportTagModal.tsx
+++ b/frontend/app/components/redesign/components/revshare/ImportTagModal.tsx
@@ -14,7 +14,7 @@ interface ImportTagModalProps {
   className?: string
 }
 
-const PLACEHOLDER_LINK_TAG = `<link rel="monetization" href="https://webmonetization.org/api/revshare/pay/your-revshare-id">`
+const PLACEHOLDER_LINK_TAG = `<link rel="monetization" href="https://tools-api.webmonetization.org/revshare/{revshare-id}">`
 
 export const ImportTagModal: React.FC<ImportTagModalProps> = ({
   isOpen,

--- a/frontend/app/components/redesign/components/revshare/RevShareInfo.tsx
+++ b/frontend/app/components/redesign/components/revshare/RevShareInfo.tsx
@@ -37,7 +37,7 @@ export const RevShareInfo = () => {
           recipient to add more rows. Assign a weight to each recipient. When
           you&apos;re finished, add the generated monetization link tag to your
           site. The link contains a unique URL hosted on
-          https://webmonetization.org/api/revshare/pay/.
+          https://tools-api.webmonetization.org/revshare/.
         </p>
       </div>
     </div>


### PR DESCRIPTION
Closes #473 

**Revshare monetization link update:**

* Changed the `PLACEHOLDER_LINK_TAG` in `ImportTagModal.tsx` to use `https://tools-api.webmonetization.org/revshare/{revshare-id}` instead of the old URL.
* Updated the instructional text in `RevShareInfo.tsx` to reference the new monetization link domain.