### PR TITLE
fix(ci): prevent Preview URLs from being disabled on production deploys

### DIFF
--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -4,6 +4,7 @@ compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
 
 workers_dev = true
+preview_urls = true
 
 kv_namespaces = [
   { binding = "PUBLISHER_TOOLS_KV", id = "b00031e45d5945c78e1eb3df6336e54a", preview_id = "preview_publisher_tools_kv" }

--- a/cdn/wrangler.toml
+++ b/cdn/wrangler.toml
@@ -2,6 +2,7 @@ name = "publisher-tools-cdn"
 compatibility_date = "2025-04-03"
 
 workers_dev = true
+preview_urls = true
 
 [assets]
 directory = "dist"

--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -5,6 +5,7 @@ main = "worker.ts"
 upload_source_maps = true
 
 workers_dev = true
+preview_urls = true
 
 kv_namespaces = [
   { binding = "PUBLISHER_TOOLS_KV", id = "b00031e45d5945c78e1eb3df6336e54a", preview_id = "preview_publisher_tools_kv" }


### PR DESCRIPTION
## Description

Closes #472 
Preview URLs (`*-publisher-tools.webmonetization.workers.dev`) are automatically disabled after each production deployment, requiring manual re-enablement through the cloudflare dashboard.

### Root Cause

- Without explicitly setting workers_dev, clf auto-disables preview URLs on deploys, assuming they are not needed with custom route set.
   - [docs state](https://developers.cloudflare.com/changelog/2025-10-23-preview-url-default-behavior/) workers Preview URL  default behavior now matches your workers.dev setting.
   - `workers_dev` controls whether clf assigns the `*workers.dev` subdomain.

What's the behaviour:
- on prod deploy, clf sees we have custom route set in workers settings (`https://webmonetization.org/tools*`)
- clf disables the Preview URLs thinking we do not need them
- we have to manually re-enabled them in dashboard

explicitly declare `workers_dev = true` will keep both custom routes and the workers.dev URLs previews active