### PR TITLE
fix(offerwall): improve dynamic colors, contrasts

### DIFF
--- a/components/src/offerwall/components/install-required/install-required.css
+++ b/components/src/offerwall/components/install-required/install-required.css
@@ -40,6 +40,7 @@ h2 {
   padding-bottom: 2rem;
   border-bottom: 1px solid;
   border-color: var(--text-color, #363636);
+  border-color: hsl(from var(--text-color, #363636) h s 70%);
 }
 
 .steps .step-content {

--- a/components/src/offerwall/components/install-required/install-required.ts
+++ b/components/src/offerwall/components/install-required/install-required.ts
@@ -6,6 +6,7 @@ import iconWallet from '@c/assets/icon_wallet.svg?raw'
 import iconClose from '@c/assets/icon_x_close.svg?raw'
 import { PoweredByInterledger } from '@c/shared/powered-by-interledger'
 import { WebMonetizationHeader } from '@c/shared/web-monetization-header'
+import { getContrastColor } from '@c/utils'
 import { getExtensionHref } from '@shared/utils/extension'
 import styles from './install-required.css?raw'
 import styleTokens from '../../vars.css?raw'
@@ -87,6 +88,13 @@ export class InstallRequired extends LitElement {
         </button>
       </div>
     `
+  }
+
+  firstUpdated(): void {
+    if (!CSS.supports('color: contrast-color(black)')) {
+      const el = this.renderRoot.querySelector<HTMLAnchorElement>('a.button')!
+      el.style.color = getContrastColor(getComputedStyle(el).backgroundColor)
+    }
   }
 
   get extensionUrl(): string {

--- a/components/src/utils.ts
+++ b/components/src/utils.ts
@@ -55,3 +55,17 @@ function getCustomFontData(fontName: FontFamilyKey, baseUrl: string) {
     }
   }
 }
+
+export function getContrastColor(colorStr: string) {
+  // Create a temporary element to let the browser normalize the color to RGB
+  const temp = document.createElement('div')
+  temp.style.color = colorStr
+  document.body.appendChild(temp)
+  const rgb = window.getComputedStyle(temp).color.match(/\d+/g)!.map(Number)
+  temp.remove()
+
+  const [r, g, b] = rgb
+  // YIQ formula
+  const yiq = (r * 299 + g * 587 + b * 114) / 1000
+  return yiq >= 128 ? '#000000' : '#ffffff'
+}


### PR DESCRIPTION
- Make the list item underline (border) dimmer than text color
- In Chrome, `color-contrast` isn't well supported. So, write some JS fallback to ensure the "install" button has good color contrast.