### PR TITLE
perf(ci/pr-checks): combine format, lint, typecheck into single job

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   lint:
-    name: Link and Typecheck
+    name: Lint and Typecheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
No need to setup env for each check - which is a waste of resources. Even if we run in parallel, the checks are fast enough to not warrant separate jobs.