### PR TITLE
refactor(config-storage-service): abstract S3 errors

### DIFF
--- a/api/src/routes/get-profile.ts
+++ b/api/src/routes/get-profile.ts
@@ -1,7 +1,10 @@
 import { HTTPException } from 'hono/http-exception'
 import z from 'zod'
 import { zValidator } from '@hono/zod-validator'
-import { ConfigStorageService } from '@shared/config-storage-service'
+import {
+  ConfigStorageService,
+  ConfigStorageServiceError,
+} from '@shared/config-storage-service'
 import { AWS_PREFIX } from '@shared/defines'
 import {
   numberToBannerFontSize,
@@ -47,12 +50,17 @@ app.get(
       return json<ToolProfile<typeof tool>>(profile)
     } catch (error) {
       if (error instanceof HTTPException) throw error
-      if (error instanceof Error) {
-        if (error.message.includes('404')) {
+      if (error instanceof ConfigStorageServiceError) {
+        if (error.code === 'not-found') {
           const msg = 'No saved profile found for given wallet address'
           throw createHTTPException(404, msg, {
-            message: 'Not found', // can include the S3 key here perhaps
+            message: 'Not found',
             code: '404',
+            cause: {
+              statusCode: error.statusCode,
+              code: error.code,
+              message: error.message,
+            },
           })
         }
       }

--- a/shared/config-storage-service/index.ts
+++ b/shared/config-storage-service/index.ts
@@ -31,10 +31,21 @@ export class ConfigStorageService {
     const response = await this.client.fetch(url)
 
     if (!response.ok) {
-      throw new Error(`S3 request failed with status: ${response.status}`)
+      const { status } = response
+      if (status === 404) {
+        const msg = 'File not found'
+        throw new ConfigStorageServiceError('not-found', status, msg)
+      }
+      const msg = 'S3 request failed'
+      throw new ConfigStorageServiceError('unknown', status, msg)
     }
 
-    return await response.json()
+    const json = await response.json()
+    if (typeof json !== 'object' || !json) {
+      const msg = 'Invalid JSON response from S3'
+      throw new ConfigStorageServiceError('not-found', response.status, msg)
+    }
+    return json as T
   }
 
   async putJson<T>(walletAddress: string, data: T): Promise<void> {
@@ -53,6 +64,17 @@ export class ConfigStorageService {
     if (!response.ok) {
       throw new Error(`Failed to upload to S3: ${response.status}`)
     }
+  }
+}
+
+export class ConfigStorageServiceError extends Error {
+  constructor(
+    public readonly code: 'not-found' | 'unknown',
+    public readonly statusCode: number,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'ConfigStorageError'
   }
 }
 


### PR DESCRIPTION
Instead of call-site checking S3-specific errors, abstract them away (which was the purpose of `ConfigStorageService`), using custom `ConfigStorageServiceError`.

@DarianM Can you update frontend code to use this custom error class as well?