### PR TITLE
fix(offerwall): no newline separation in the How it works text

### DIFF
--- a/frontend/app/components/offerwall/HowItWorks.tsx
+++ b/frontend/app/components/offerwall/HowItWorks.tsx
@@ -53,10 +53,8 @@ export default function HowItWorks() {
         </Heading4>
         <BodyStandard className="text-center xl:text-left">
           If you have a Google Ad Manager account you can add Web Monetization
-          to your Offerwall.
-          <br />
-          Customize the user choice screen here, then copy the generated script
-          and add it to your website.
+          to your Offerwall. Customize the user choice screen here, then copy
+          the generated script and add it to your website.
         </BodyStandard>
       </header>
 


### PR DESCRIPTION
See https://github.com/interledger/publisher-tools/pull/572#issuecomment-3990104348
Closes #594 

Keep the text inline as per design
https://www.figma.com/design/0S8Oj8ZB5MvkGtIrVRswDH/Web-Monetization?node-id=7030-129177&m=dev