### PR TITLE
fix(frontend/builder): prevent refresh button on click to collapse the accordion

### DIFF
--- a/frontend/app/components/redesign/components/BuilderAccordion.tsx
+++ b/frontend/app/components/redesign/components/BuilderAccordion.tsx
@@ -59,15 +59,20 @@ export const BuilderAccordion: React.FC<Props> = ({
             <GhostButton
               icon="refresh"
               iconPosition="left"
-              onClick={onRefresh}
+              onClick={(e) => {
+                e.stopPropagation()
+                onRefresh()
+              }}
               aria-label={`Reset ${title.toLowerCase()} to default`}
             >
               Back to default
             </GhostButton>
           )}
-          <SVGArrowCollapse
-            className={cx('w-12 h-12 p-3.5', !isOpen && 'rotate-180')}
-          />
+          {onDone && (
+            <SVGArrowCollapse
+              className={cx('w-12 h-12 p-3.5', !isOpen && 'rotate-180')}
+            />
+          )}
         </div>
       </summary>
 


### PR DESCRIPTION
#### Context

- prevent refresh button click to bubble up to `summary` on close the accordion
- hide collapse arrow for the offerwall builder that cannot be collapsed 

regression after #605 