### PR TITLE
fix(frontend/builder): mobile reset changes button spacing

### DIFF
--- a/frontend/app/components/redesign/components/BuilderAccordion.tsx
+++ b/frontend/app/components/redesign/components/BuilderAccordion.tsx
@@ -64,8 +64,9 @@ export const BuilderAccordion: React.FC<Props> = ({
                 onRefresh()
               }}
               aria-label={`Reset ${title.toLowerCase()} to default`}
+              className="text-xs sm:text-sm gap-xs"
             >
-              Back to default
+              Reset changes
             </GhostButton>
           )}
           {onDone && (


### PR DESCRIPTION
| Before      | After       |
|:------------|:-----------:|
| <img width="447" height="237" alt="image" src="https://github.com/user-attachments/assets/65e6ad4c-6725-435c-9797-c124f02d6696" />  | <img width="440" height="228" alt="image" src="https://github.com/user-attachments/assets/1b97e8a8-c9c7-4634-ba40-e63d07b6eed2" />    |

regression after https://github.com/interledger/publisher-tools/pull/605
Also, the button message was a bit confusing 