### PR TITLE
fix(offerwall): open webmonetization.org link in new tab

### DIFF
--- a/components/src/offerwall/components/install-required/install-required.ts
+++ b/components/src/offerwall/components/install-required/install-required.ts
@@ -72,7 +72,7 @@ export class InstallRequired extends LitElement {
           <p class="semi-bold">
             <span
               >Find out more on
-              <a href="https://webmonetization.org"
+              <a href="https://webmonetization.org" target="_blank"
                 >webmonetization.org</a
               ></span
             >


### PR DESCRIPTION
## Summary

Adds `target="_blank"` to the “Find out more on webmonetization.org” link in the offerwall **install-required** view so it opens in a new tab

## Testing

- Open the install-required offerwall state and click the webmonetization.org link; it should open in a new tab.

Closes #615