### PR TITLE
fix(frontend): vars naming mismatch through build pipeline

### DIFF
--- a/.github/workflows/deploy-worker/action.yml
+++ b/.github/workflows/deploy-worker/action.yml
@@ -44,10 +44,10 @@ inputs:
   BUILD_AWS_PREFIX:
     description: 'AWS_PREFIX used for config storage'
     required: true
-  BUILD_UMAMI_HOST:
+  UMAMI_HOST:
     description: 'Umami analytics host URL'
     required: false
-  BUILD_UMAMI_WEBSITE_ID:
+  UMAMI_WEBSITE_ID:
     description: 'Umami analytics website ID'
     required: false
 
@@ -74,8 +74,8 @@ runs:
         BUILD_API_URL: ${{ inputs.BUILD_API_URL }}
         BUILD_CDN_URL: ${{ inputs.BUILD_CDN_URL }}
         BUILD_AWS_PREFIX: ${{ inputs.BUILD_AWS_PREFIX }}
-        BUILD_UMAMI_HOST: ${{ inputs.BUILD_UMAMI_HOST }}
-        BUILD_UMAMI_WEBSITE_ID: ${{ inputs.BUILD_UMAMI_WEBSITE_ID }}
+        UMAMI_HOST: ${{ inputs.UMAMI_HOST }}
+        UMAMI_WEBSITE_ID: ${{ inputs.UMAMI_WEBSITE_ID }}
 
     - name: Get worker deploy command
       if: ${{ inputs.skip-deploy == 'false' && (inputs.changed == 'true' || inputs.mode == 'production') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -170,8 +170,8 @@ jobs:
           BUILD_API_URL: ${{ steps.api.outputs.url }}
           BUILD_CDN_URL: ${{ steps.cdn.outputs.url }}
           BUILD_AWS_PREFIX: ${{ vars.AWS_PREFIX }}
-          BUILD_UMAMI_HOST: ${{ vars.UMAMI_HOST }}
-          BUILD_UMAMI_WEBSITE_ID: ${{ vars.UMAMI_WEBSITE_ID }}
+          UMAMI_HOST: ${{ vars.UMAMI_HOST }}
+          UMAMI_WEBSITE_ID: ${{ vars.UMAMI_WEBSITE_ID }}
           stagingUrl: ${{ vars.APP_STAGING_URL }}
           productionUrl: ${{ vars.APP_PRODUCTION_URL }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,8 +15,8 @@ export default defineConfig(({ mode, isSsrBuild }) => ({
   define: {
     BUILD_CDN_URL: JSON.stringify(process.env.BUILD_CDN_URL),
     BUILD_API_URL: JSON.stringify(process.env.BUILD_API_URL),
-    BUILD_UMAMI_HOST: JSON.stringify(process.env.UMAMI_HOST),
-    BUILD_UMAMI_WEBSITE_ID: JSON.stringify(process.env.UMAMI_WEBSITE_ID),
+    BUILD_UMAMI_HOST: JSON.stringify(process.env.BUILD_UMAMI_HOST),
+    BUILD_UMAMI_WEBSITE_ID: JSON.stringify(process.env.BUILD_UMAMI_WEBSITE_ID),
   },
   plugins: [
     cloudflare({

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,8 +15,8 @@ export default defineConfig(({ mode, isSsrBuild }) => ({
   define: {
     BUILD_CDN_URL: JSON.stringify(process.env.BUILD_CDN_URL),
     BUILD_API_URL: JSON.stringify(process.env.BUILD_API_URL),
-    BUILD_UMAMI_HOST: JSON.stringify(process.env.BUILD_UMAMI_HOST),
-    BUILD_UMAMI_WEBSITE_ID: JSON.stringify(process.env.BUILD_UMAMI_WEBSITE_ID),
+    BUILD_UMAMI_HOST: JSON.stringify(process.env.UMAMI_HOST),
+    BUILD_UMAMI_WEBSITE_ID: JSON.stringify(process.env.UMAMI_WEBSITE_ID),
   },
   plugins: [
     cloudflare({


### PR DESCRIPTION
Related to #651 
Drop the `BUILD_` prefix convention for vars never injected by clf at runtime. 
These vars are purely build-time, so there's no collision risk or reason to rename them with `BUILD_`