### PR TITLE
chore(ci/setup): update dependencies, action setup

### DIFF
--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -1,4 +1,4 @@
-name: 'WMTools Environment Setup'
+name: 'Publisher Tools Environment Setup'
 description: 'Installs NodeJS, PNPM, dependencies and PNPM restores cache'
 
 runs:
@@ -6,29 +6,13 @@ runs:
   using: 'composite'
 
   steps:
+    - name: Install PNPM
+      uses: pnpm/action-setup@v5
+
     - name: Setup NodeJS
       uses: actions/setup-node@v6
-      with: { node-version-file: .nvmrc }
-
-    - name: Install PNPM
-      uses: pnpm/action-setup@v2
-      with:
-        run_install: false
-        # we do not need to specify PNPM's version since we have the `packageManager`
-        # property set in `package.json`
-
-    - name: Get PNPM store path
-      id: pnpm-cache
-      shell: bash
-      run: |
-        echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-    - name: Setup PNPM cache
-      uses: actions/cache@v5
-      with:
-        path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+      with: { node-version-file: .nvmrc, cache: 'pnpm' }
 
     - name: Install dependencies
       shell: bash
-      run: pnpm install --frozen-lockfile
+      run: pnpm install


### PR DESCRIPTION
Based on https://github.com/actions/setup-node/blob/v6.4.0/docs/advanced-usage.md#caching-packages-data

We were using v2 of pnpm-setup. Saw a warning in past runs, as it uses Node.js v20.