### PR TITLE
fix(widget): pass `limits.receiver` to payment grant request

### DIFF
--- a/api/src/routes/payment.ts
+++ b/api/src/routes/payment.ts
@@ -52,8 +52,13 @@ app.post(
   zValidator('json', PaymentGrantSchema),
   async ({ req, json, env }) => {
     try {
-      const { walletAddress, debitAmount, receiveAmount, redirectUrl } =
-        req.valid('json')
+      const {
+        walletAddress,
+        incomingPaymentId,
+        debitAmount,
+        receiveAmount,
+        redirectUrl,
+      } = req.valid('json')
       if (!isAllowedRedirectUrl(redirectUrl)) {
         throw createHTTPException(400, 'Invalid redirect URL', {})
       }
@@ -61,6 +66,7 @@ app.post(
       const openPayments = await OpenPaymentsService.getInstance(env)
       const result = await openPayments.initializePayment({
         walletAddress,
+        incomingPaymentId,
         debitAmount,
         receiveAmount,
         redirectUrl,

--- a/api/src/schemas/payment.ts
+++ b/api/src/schemas/payment.ts
@@ -27,6 +27,7 @@ const WalletAddressSchema = z
 export const PaymentGrantSchema = z.object({
   redirectUrl: z.url(),
   walletAddress: WalletAddressSchema,
+  incomingPaymentId: z.url(),
   debitAmount: AmountSchema,
   receiveAmount: AmountSchema,
 })

--- a/api/src/utils/open-payments.ts
+++ b/api/src/utils/open-payments.ts
@@ -44,6 +44,7 @@ type QuoteGrantParams = {
 
 type CreateOutgoingPaymentParams = {
   walletAddress: WalletAddress
+  incomingPaymentId: string
   debitAmount: Amount
   receiveAmount?: Amount
   nonce?: string
@@ -209,6 +210,7 @@ export class OpenPaymentsService {
 
   async initializePayment(args: {
     walletAddress: WalletAddress
+    incomingPaymentId: string
     debitAmount: Amount
     receiveAmount: Amount
     redirectUrl: string
@@ -218,6 +220,7 @@ export class OpenPaymentsService {
 
     const outgoingPaymentGrant = await this.createOutgoingPaymentGrant({
       walletAddress: args.walletAddress,
+      incomingPaymentId: args.incomingPaymentId,
       debitAmount: args.debitAmount,
       receiveAmount: args.receiveAmount,
       nonce: clientNonce,
@@ -384,6 +387,7 @@ export class OpenPaymentsService {
   ): Promise<PendingGrant> {
     const {
       walletAddress,
+      incomingPaymentId,
       debitAmount,
       nonce,
       paymentId,
@@ -406,6 +410,7 @@ export class OpenPaymentsService {
                 type: 'outgoing-payment',
                 actions: ['create', 'read'],
                 limits: {
+                  receiver: incomingPaymentId,
                   debitAmount: debitAmount,
                 },
               },

--- a/components/src/widget/views/confirmation/confirmation.ts
+++ b/components/src/widget/views/confirmation/confirmation.ts
@@ -289,6 +289,7 @@ export class PaymentConfirmation extends LitElement {
       const { walletAddress, quote } = this.configController.state
       const { grant, paymentId } = await this.requestOutgoingGrant({
         walletAddress,
+        incomingPaymentId: quote.receiver,
         debitAmount: quote.debitAmount,
         receiveAmount: quote.receiveAmount,
       })
@@ -321,6 +322,7 @@ export class PaymentConfirmation extends LitElement {
 
   private async requestOutgoingGrant(paymentData: {
     walletAddress: WalletAddress
+    incomingPaymentId: string
     debitAmount: Amount
     receiveAmount: Amount
   }): Promise<{ grant: PendingGrant; paymentId: string }> {
@@ -335,6 +337,7 @@ export class PaymentConfirmation extends LitElement {
       },
       body: JSON.stringify({
         redirectUrl,
+        incomingPaymentId: paymentData.incomingPaymentId,
         walletAddress:
           paymentData.walletAddress as PaymentGrantInput['walletAddress'],
         debitAmount: paymentData.debitAmount,


### PR DESCRIPTION
As discussed in Open Payments call yesterday.