### PR TITLE
fix(api): correctly format ZodError responses

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -21,7 +21,8 @@ app.use('*', async (c, next) => {
   await next()
   if (c.res.status !== 400) return
 
-  const data = await c.res.clone().json()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const data: any = await c.res.clone().json()
   if (data?.error?.name === 'ZodError' && data.error.message?.startsWith('[')) {
     c.res = c.json(
       {

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -17,6 +17,22 @@ export type Env = {
 
 export const app = new Hono<{ Bindings: Env }>()
 
+app.use('*', async (c, next) => {
+  await next()
+  if (c.res.status !== 400) return
+
+  const data = await c.res.clone().json()
+  if (data?.error?.name === 'ZodError' && data.error.message?.startsWith('[')) {
+    c.res = c.json(
+      {
+        ...data,
+        error: { ...data.error, message: JSON.parse(data.error.message) },
+      },
+      c.res.status,
+    )
+  }
+})
+
 app.use(
   '*',
   cors({

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -17,23 +17,6 @@ export type Env = {
 
 export const app = new Hono<{ Bindings: Env }>()
 
-app.use('*', async (c, next) => {
-  await next()
-  if (c.res.status !== 400) return
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const data: any = await c.res.clone().json()
-  if (data?.error?.name === 'ZodError' && data.error.message?.startsWith('[')) {
-    c.res = c.json(
-      {
-        ...data,
-        error: { ...data.error, message: JSON.parse(data.error.message) },
-      },
-      c.res.status,
-    )
-  }
-})
-
 app.use(
   '*',
   cors({

--- a/api/src/routes/get-profile.ts
+++ b/api/src/routes/get-profile.ts
@@ -1,6 +1,5 @@
 import { HTTPException } from 'hono/http-exception'
 import z from 'zod'
-import { zValidator } from '@hono/zod-validator'
 import {
   ConfigStorageService,
   ConfigStorageServiceError,
@@ -11,17 +10,17 @@ import { AWS_PREFIX } from '@shared/defines'
 import { PROFILE_IDS, TOOLS } from '@shared/types'
 import type { Configuration } from '@shared/types'
 import { app } from '../app.js'
-import { createHTTPException } from '../utils/utils.js'
+import { createHTTPException, validate } from '../utils/utils.js'
 
 app.get(
   '/profile/:tool',
-  zValidator(
+  validate(
     'param',
     z.object({
       tool: z.enum(TOOLS),
     }),
   ),
-  zValidator(
+  validate(
     'query',
     z.object({
       wa: z.url(),

--- a/api/src/routes/payment/initiate.ts
+++ b/api/src/routes/payment/initiate.ts
@@ -1,6 +1,5 @@
 import { HTTPException } from 'hono/http-exception'
 import z from 'zod'
-import { zValidator } from '@hono/zod-validator'
 import { createId } from '@paralleldrive/cuid2'
 import { app } from '../../app'
 import {
@@ -9,7 +8,7 @@ import {
 } from '../../schemas/payment'
 import { OpenPaymentsService } from '../../utils/open-payments'
 import { setData } from '../../utils/payments-kv'
-import { createHTTPException } from '../../utils/utils'
+import { createHTTPException, validate } from '../../utils/utils'
 
 const PaymentInitiateSchema = z
   .object({
@@ -30,7 +29,7 @@ export type PaymentInitiateResult = {
 
 app.post(
   '/payment/initiate',
-  zValidator('json', PaymentInitiateSchema),
+  validate('json', PaymentInitiateSchema),
   async ({ req, json, env }) => {
     try {
       const params = req.valid('json')

--- a/api/src/routes/payment/quotes.ts
+++ b/api/src/routes/payment/quotes.ts
@@ -1,5 +1,4 @@
 import z from 'zod'
-import { zValidator } from '@hono/zod-validator'
 import type { Amount, PaymentError } from '@shared/types'
 import { app } from '../../app.js'
 import {
@@ -10,7 +9,7 @@ import {
   isNonPositiveAmountError,
   OpenPaymentsService,
 } from '../../utils/open-payments.js'
-import { createHTTPException } from '../../utils/utils.js'
+import { createHTTPException, validate } from '../../utils/utils.js'
 
 const PaymentQuoteSchema = z
   .object({
@@ -23,7 +22,7 @@ export type PaymentQuoteInput = z.infer<typeof PaymentQuoteSchema>
 
 app.post(
   '/payment/quotes',
-  zValidator('json', PaymentQuoteSchema),
+  validate('json', PaymentQuoteSchema),
   async ({ req, json, env }) => {
     try {
       const openPayments = await OpenPaymentsService.getInstance(env)

--- a/api/src/routes/payment/redirect.ts
+++ b/api/src/routes/payment/redirect.ts
@@ -1,12 +1,11 @@
 import { HTTPException } from 'hono/http-exception'
 import z from 'zod'
-import { zValidator } from '@hono/zod-validator'
 import { urlWithParams } from '@shared/utils'
 import { app } from '../../app'
 import { PaymentIdSchema } from '../../schemas/payment'
 import { OpenPaymentsService } from '../../utils/open-payments'
 import { getData, setData } from '../../utils/payments-kv'
-import { createHTTPException } from '../../utils/utils'
+import { createHTTPException, validate } from '../../utils/utils'
 
 export const PaymentStatusSuccessSchema = z.object({
   hash: z.string().min(1, 'Hash is required'),
@@ -33,8 +32,8 @@ export type PaymentStatusRejected = z.infer<typeof PaymentStatusRejectedSchema>
 // as grant is accepted, outgoing-payment will be created.
 app.get(
   '/payment/redirect/:paymentId',
-  zValidator('param', z.object({ paymentId: PaymentIdSchema })),
-  zValidator('query', PaymentStatusSchema),
+  validate('param', z.object({ paymentId: PaymentIdSchema })),
+  validate('query', PaymentStatusSchema),
   async ({ req, redirect, env }) => {
     try {
       const openPayments = await OpenPaymentsService.getInstance(env)

--- a/api/src/routes/payment/status2.ts
+++ b/api/src/routes/payment/status2.ts
@@ -1,15 +1,14 @@
 import { HTTPException } from 'hono/http-exception'
 import z from 'zod'
-import { zValidator } from '@hono/zod-validator'
 import { app, type Env } from '../../app'
 import { PaymentIdSchema } from '../../schemas/payment'
 import { OpenPaymentsService } from '../../utils/open-payments'
 import { getData, setData, type PaymentKvData } from '../../utils/payments-kv'
-import { createHTTPException } from '../../utils/utils'
+import { createHTTPException, validate } from '../../utils/utils'
 
 app.get(
   '/payment/status/:paymentId',
-  zValidator('param', z.object({ paymentId: PaymentIdSchema })),
+  validate('param', z.object({ paymentId: PaymentIdSchema })),
   async ({ req, json, env }) => {
     const { paymentId } = req.param()
 

--- a/api/src/routes/probabilistic-revshare.ts
+++ b/api/src/routes/probabilistic-revshare.ts
@@ -1,16 +1,15 @@
 import { HTTPException } from 'hono/http-exception'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import z from 'zod'
-import { zValidator } from '@hono/zod-validator'
 import type { WalletAddress } from '@interledger/open-payments'
 import { decode, pickWeightedRandom } from '@shared/probabilistic-revenue-share'
 import { isWalletAddress, validateWalletAddressOrPointer } from '@shared/utils'
 import { app } from '../app.js'
-import { createHTTPException } from '../utils/utils'
+import { createHTTPException, validate } from '../utils/utils'
 
 app.get(
   '/revshare/:payload',
-  zValidator(
+  validate(
     'param',
     z.object({
       payload: z.base64url().max(50_000).min(20),

--- a/api/src/routes/wallet.ts
+++ b/api/src/routes/wallet.ts
@@ -1,5 +1,4 @@
 import z from 'zod'
-import { zValidator } from '@hono/zod-validator'
 import type { WalletAddress } from '@interledger/open-payments'
 import {
   getWalletAddress,
@@ -8,7 +7,7 @@ import {
   WalletAddressFormatError,
 } from '@shared/utils'
 import { app } from '../app.js'
-import { createHTTPException } from '../utils/utils.js'
+import { createHTTPException, validate } from '../utils/utils.js'
 
 const walletAddressSchema = z.object({
   walletAddress: z.url('Wallet address must be a valid URL'),
@@ -20,7 +19,7 @@ export interface WalletAddressInfo extends WalletAddress {
 
 app.get(
   '/wallet',
-  zValidator('query', walletAddressSchema),
+  validate('query', walletAddressSchema),
   async ({ req, json }) => {
     const { walletAddress } = req.valid('query')
 

--- a/api/src/utils/utils.ts
+++ b/api/src/utils/utils.ts
@@ -1,8 +1,11 @@
+import type { ValidationTargets } from 'hono'
 import { HTTPException } from 'hono/http-exception'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import type { Request } from 'http-message-signatures'
 import { signMessage } from 'http-message-signatures/lib/httpbis'
 import { createContentDigestHeader } from 'httpbis-digest-headers'
+import type { ZodType } from 'zod'
+import { zValidator } from '@hono/zod-validator'
 import { signAsync } from '@noble/ed25519'
 
 type Headers = SignatureHeaders & Partial<ContentHeaders>
@@ -136,5 +139,14 @@ export function createHTTPException(
   return new HTTPException(statusCode, {
     message,
     cause: serializedError,
+  })
+}
+
+export const validate = <T extends keyof ValidationTargets, S extends ZodType>(
+  target: T,
+  schema: S,
+) => {
+  return zValidator(target, schema, (result) => {
+    if (!result.success) throw result.error
   })
 }


### PR DESCRIPTION
```diff
# GET /profile/unknown-tool
--- text	Original
+++ text	Modified
@@ -1,7 +1,15 @@
 {
-  "success": false,
   "error": {
-    "name": "ZodError",
-    "message": "[\n  {\n    \"code\": \"invalid_value\",\n    \"values\": [\n      \"banner\",\n      \"widget\",\n      \"offerwall\"\n    ],\n    \"path\": [\n      \"tool\"\n    ],\n    \"message\": \"Invalid option: expected one of \\\"banner\\\"|\\\"widget\\\"|\\\"offerwall\\\"\"\n  }\n]"
+    "message": "Validation failed",
+    "code": "VALIDATION_ERROR",
+    "details": {
+      "issues": [
+        {
+          "path": "tool",
+          "message": "Invalid option: expected one of \"banner\"|\"widget\"|\"offerwall\"",
+          "code": "invalid_value"
+        }
+      ]
+    }
   }
 }
```