### PR TITLE
fix(paywall): normalize URLs at database level only

### DIFF
--- a/api/src/utils/payments-db.test.ts
+++ b/api/src/utils/payments-db.test.ts
@@ -1,5 +1,6 @@
 import { env } from 'cloudflare:workers'
 import { describe, it, expect, beforeEach } from 'vitest'
+import { ensureEnd } from '@shared/utils'
 import {
   savePayment,
   getPayment,
@@ -69,6 +70,37 @@ describe('Paywall Database', () => {
     ).resolves.toBeFalsy()
   })
 
+  it('should normalize URLs when storing payments', async () => {
+    const url = new URL(mockPayment.url)
+    url.searchParams.set('foo', 'bar')
+    await savePayment(DB, { ...mockPayment, url })
+    await expect(
+      DB.exec(sql`SELECT * from paywall_payments`),
+    ).resolves.toMatchObject({ count: 1 })
+
+    await expect(
+      hasPayment(DB, url.href, {
+        ...mockPayment.sender,
+        id: 'https://wallet.com/sender2',
+      }),
+    ).resolves.toBe('complete')
+
+    url.searchParams.set('bar', 'baz')
+    await expect(
+      hasPayment(DB, url.href, {
+        ...mockPayment.sender,
+        id: 'https://wallet.com/sender2',
+      }),
+    ).resolves.toBe('complete')
+
+    await expect(
+      hasPayment(DB, url.origin + ensureEnd(url.pathname, '/'), {
+        ...mockPayment.sender,
+        id: 'https://wallet.com/sender2',
+      }),
+    ).resolves.toBe('complete')
+  })
+
   it('should fetch the full, reconstructed payment record using getPayment', async () => {
     await savePayment(DB, mockPayment)
     const result = await getPayment(DB, mockPayment.paymentId)
@@ -81,7 +113,7 @@ describe('Paywall Database', () => {
     // Assert the fields contain the hashed values, not plain text
     expect(result!.url).not.toBe(mockPayment.url.href)
     expect(result!.sender.id).not.toBe(mockPayment.sender.id)
-    const urlHash = await hash(mockPayment.url.href)
+    const urlHash = await hash(ensureEnd(mockPayment.url.href, '/'))
     expect(result!.url).toBe(urlHash)
   })
 

--- a/api/src/utils/payments-db.ts
+++ b/api/src/utils/payments-db.ts
@@ -1,5 +1,6 @@
 import type { D1Database } from '@cloudflare/workers-types'
 import type { Amount } from '@shared/types'
+import { ensureEnd } from '@shared/utils'
 import type { WalletAddressInfo } from '../types'
 
 /** for syntax highlighting */
@@ -7,10 +8,11 @@ export const sql = String.raw
 
 export async function savePayment(db: D1Database, data: Payment) {
   const site = getSite(data.url)
+  const normalizedUrl = normalizeUrl(data.url)
   const now = Date.now()
 
   const [hashedUrl, hashedSenderId, hashedSenderUrl] = await Promise.all([
-    hash(data.url.href),
+    hash(normalizedUrl),
     hash(data.sender.id),
     hash(data.sender.$url),
   ])
@@ -88,8 +90,9 @@ export async function hasPayment(
   url: string,
   payer: Pick<WalletAddressInfo, 'id' | '$url'>,
 ): Promise<false | PaymentStatus> {
+  const normalizedUrl = normalizeUrl(new URL(url))
   const [hashedUrl, hashedPayerWalletAddressId, hashedPayerWalletAddressUrl] =
-    await Promise.all([hash(url), hash(payer.id), hash(payer.$url)])
+    await Promise.all([hash(normalizedUrl), hash(payer.id), hash(payer.$url)])
 
   const res = await db
     .prepare(
@@ -159,6 +162,12 @@ function mapStatusIdToStatus(status: 0 | 1): PaymentStatus {
 
 function getSite(url: URL) {
   return url.hostname
+}
+
+function normalizeUrl(url: URL) {
+  const { origin, pathname } = url
+  const path = /\.html?$/.test(pathname) ? pathname : ensureEnd(pathname, '/')
+  return origin + path
 }
 
 export async function hash(text: string): Promise<HashedString> {

--- a/cdn/src/paywall.ts
+++ b/cdn/src/paywall.ts
@@ -8,7 +8,6 @@ import {
   getWallet,
   initiatePayment,
 } from './utils'
-import { getPageUrl } from './utils/paywall-utils'
 
 const NAME = 'wm-paywall'
 customElements.define(NAME, Paywall)
@@ -22,7 +21,7 @@ function drawPaywall() {
     throw new Error(`Invalid data-price="${price}"`)
   }
 
-  const pageUrl = getPageUrl(window.location)
+  const pageUrl = window.location.href
 
   const element = document.createElement('wm-paywall')
   if (price) element.setPrice(price)

--- a/cdn/src/utils/paywall-utils.ts
+++ b/cdn/src/utils/paywall-utils.ts
@@ -1,7 +1,0 @@
-import { ensureEnd } from '@shared/utils'
-
-export function getPageUrl(url: URL | Location) {
-  const { origin, pathname } = url
-  const path = /\.html?$/.test(pathname) ? pathname : ensureEnd(pathname, '/')
-  return origin + path
-}


### PR DESCRIPTION
Instead of passing a normalized url to backend, pass the full URL (as we want to redirect to original URL instead of normalized one); but keep stored URL (hashes) with normalized URLs.

Noticed this during preview (https://test.sidvishnoi.com/web-monetization/publisher-tools/paywall.html?src=727) that the `?src` param gets removed on redirect and the preview ends up not using the PR for script preview.

Part of https://github.com/interledger/publisher-tools/issues/672
Part of https://github.com/interledger/publisher-tools/issues/677
Part of https://github.com/interledger/publisher-tools/issues/670 (story)