### PR TITLE
fix(api/payments-db): correctly return status when set to failed

### DIFF
--- a/api/src/utils/payments-db.ts
+++ b/api/src/utils/payments-db.ts
@@ -75,7 +75,7 @@ export async function setPaymentStatus(
         )
         .bind(paymentId),
     ])
-    return res[0].meta.changes + res[0].meta.changes === 2
+    return res[0].meta.changes + res[1].meta.changes === 2
   }
 
   const res = await db

--- a/api/src/utils/payments-db.ts
+++ b/api/src/utils/payments-db.ts
@@ -64,11 +64,11 @@ export async function setPaymentStatus(
     const res = await db.batch([
       db
         .prepare(
-          sql`DELETE FROM paywall_payments_meta WHERE paymentId = ?
+          sql`DELETE FROM paywall_payments_meta WHERE paymentId = ?1
               AND EXISTS (SELECT 1 FROM paywall_payments
-                WHERE paymentId = ? AND status = 0)`,
+                WHERE paymentId = ?1 AND status = 0)`,
         )
-        .bind(paymentId, paymentId),
+        .bind(paymentId),
       db
         .prepare(
           sql`DELETE FROM paywall_payments WHERE paymentId = ? AND status = 0`,


### PR DESCRIPTION
- Correctly return boolean check if actually deleted.
- Simplify the query to not require same value being `.bind()` twice.

Also, to trigger a deploy as last push to main didn't.