### PR TITLE
refactor(frontend/stores): reuse profile commit logic

### DIFF
--- a/frontend/app/stores/banner-store.ts
+++ b/frontend/app/stores/banner-store.ts
@@ -13,7 +13,7 @@ import type { SaveResult } from '~/lib/types'
 import { createWalletStore } from '~/stores/wallet-store'
 import { getToolProfiles, saveToolProfile } from '~/utils/profile-api'
 import { patchProxy, splitProfileProperties } from '~/utils/utils.storage'
-import { createToolStoreUtils, getStorageKeys } from '~/utils/utilts.store'
+import { createToolStoreUtils } from '~/utils/utils.store'
 import { toolState } from './toolStore'
 
 export const {
@@ -74,8 +74,6 @@ const bannerStoreUtils = createToolStoreUtils({
   snapshots,
 })
 
-const { snapshotsStorageKey } = getStorageKeys(TOOL_BANNER)
-
 export const actions = {
   setProfileName(name: string) {
     banner.profiles[toolState.activeTab].$name = name
@@ -117,22 +115,10 @@ export const actions = {
     )
   },
   commitProfile() {
-    const profile = snapshot(banner.profile)
-    snapshots.set(toolState.activeTab, profile)
-    banner.profilesUpdate.delete(toolState.activeTab)
-
-    const snaps = Object.fromEntries(snapshots.entries())
-    localStorage.setItem(snapshotsStorageKey, JSON.stringify(snaps))
+    bannerStoreUtils.commitActiveProfile(toolState.activeTab)
   },
   commitProfiles() {
-    PROFILE_IDS.forEach((id) => {
-      const profile = snapshot(banner.profiles[id])
-      snapshots.set(id, profile)
-      banner.profilesUpdate.delete(id)
-    })
-
-    const snaps = Object.fromEntries(snapshots.entries())
-    localStorage.setItem(snapshotsStorageKey, JSON.stringify(snaps))
+    bannerStoreUtils.commitAllProfiles()
   },
 }
 

--- a/frontend/app/stores/offerwall-store.ts
+++ b/frontend/app/stores/offerwall-store.ts
@@ -13,7 +13,7 @@ import type { SaveResult } from '~/lib/types'
 import { createWalletStore } from '~/stores/wallet-store'
 import { getToolProfiles, saveToolProfile } from '~/utils/profile-api'
 import { patchProxy } from '~/utils/utils.storage'
-import { createToolStoreUtils, getStorageKeys } from '~/utils/utilts.store'
+import { createToolStoreUtils } from '~/utils/utils.store'
 import { toolState } from './toolStore'
 
 export const {
@@ -74,8 +74,6 @@ const offerwallStoreUtils = createToolStoreUtils({
   snapshots,
 })
 
-const { snapshotsStorageKey } = getStorageKeys(TOOL_OFFERWALL)
-
 export const actions = {
   setProfileName(name: string) {
     offerwall.profiles[toolState.activeTab].$name = name
@@ -118,22 +116,10 @@ export const actions = {
     )
   },
   commitProfile() {
-    const profile = snapshot(offerwall.profile)
-    snapshots.set(toolState.activeTab, profile)
-    offerwall.profilesUpdate.delete(toolState.activeTab)
-
-    const snaps = Object.fromEntries(snapshots.entries())
-    localStorage.setItem(snapshotsStorageKey, JSON.stringify(snaps))
+    offerwallStoreUtils.commitActiveProfile(toolState.activeTab)
   },
   commitProfiles() {
-    PROFILE_IDS.forEach((id) => {
-      const profile = snapshot(offerwall.profiles[id])
-      snapshots.set(id, profile)
-      offerwall.profilesUpdate.delete(id)
-    })
-
-    const snaps = Object.fromEntries(snapshots.entries())
-    localStorage.setItem(snapshotsStorageKey, JSON.stringify(snaps))
+    offerwallStoreUtils.commitAllProfiles()
   },
 }
 

--- a/frontend/app/stores/widget-store.ts
+++ b/frontend/app/stores/widget-store.ts
@@ -13,7 +13,7 @@ import type { SaveResult } from '~/lib/types'
 import { createWalletStore } from '~/stores/wallet-store'
 import { getToolProfiles, saveToolProfile } from '~/utils/profile-api'
 import { patchProxy, splitProfileProperties } from '~/utils/utils.storage'
-import { createToolStoreUtils, getStorageKeys } from '~/utils/utilts.store'
+import { createToolStoreUtils } from '~/utils/utils.store'
 import { toolState } from './toolStore'
 
 export const {
@@ -73,8 +73,6 @@ const widgetStoreUtils = createToolStoreUtils({
   snapshots,
 })
 
-const { snapshotsStorageKey } = getStorageKeys(TOOL_WIDGET)
-
 export const actions = {
   setProfileName(name: string) {
     widget.profiles[toolState.activeTab].$name = name
@@ -116,23 +114,10 @@ export const actions = {
     )
   },
   commitProfile() {
-    const profile = snapshot(widget.profile)
-    snapshots.set(toolState.activeTab, profile)
-    widget.profilesUpdate.delete(toolState.activeTab)
-
-    const snaps = Object.fromEntries(snapshots.entries())
-    localStorage.setItem(snapshotsStorageKey, JSON.stringify(snaps))
+    widgetStoreUtils.commitActiveProfile(toolState.activeTab)
   },
   commitProfiles() {
-    PROFILE_IDS.forEach((id) => {
-      const profile = snapshot(widget.profiles[id])
-
-      snapshots.set(id, profile)
-      widget.profilesUpdate.delete(id)
-    })
-
-    const snaps = Object.fromEntries(snapshots.entries())
-    localStorage.setItem(snapshotsStorageKey, JSON.stringify(snaps))
+    widgetStoreUtils.commitAllProfiles()
   },
 }
 

--- a/frontend/app/utils/utils.store.ts
+++ b/frontend/app/utils/utils.store.ts
@@ -94,6 +94,13 @@ export function createToolStoreUtils<T extends Tool>(
     })
   }
 
+  function persistSnapshots() {
+    localStorage.setItem(
+      snapshotsStorageKey,
+      JSON.stringify(Object.fromEntries(snapshots)),
+    )
+  }
+
   return {
     subscribeProfilesToStorage() {
       const unsubscribes = PROFILE_IDS.map(subscribeProfileToStorage)
@@ -143,6 +150,22 @@ export function createToolStoreUtils<T extends Tool>(
     subscribeProfilesToUpdates() {
       const unsubscribes = PROFILE_IDS.map(subscribeProfileToUpdates)
       return () => unsubscribes.forEach((s) => s())
+    },
+
+    commitActiveProfile(activeTab: ProfileId): void {
+      const current = snapshot(store.profiles[activeTab]) as ToolProfile<T>
+      snapshots.set(activeTab, current)
+      store.profilesUpdate.delete(activeTab)
+      persistSnapshots()
+    },
+
+    commitAllProfiles(): void {
+      PROFILE_IDS.forEach((id) => {
+        const profile = snapshot(store.profiles[id]) as ToolProfile<T>
+        snapshots.set(id, profile)
+        store.profilesUpdate.delete(id)
+      })
+      persistSnapshots()
     },
 
     removeProfilesFromStorage() {


### PR DESCRIPTION
Apart of #718 

## Changes
- Moving profile commit logic into a shared utility
-  Fix typo for `utils.store.ts`