### PR TITLE
fix(api/paywall): return `paymentId` with pending entitlement

### DIFF
--- a/api/src/routes/paywall/entitlement.ts
+++ b/api/src/routes/paywall/entitlement.ts
@@ -1,6 +1,6 @@
 import z from 'zod'
 import { app } from '../../app'
-import { hasPayment } from '../../utils/payments-db'
+import { findPayment } from '../../utils/payments-db'
 import { createHTTPException, validate } from '../../utils/utils'
 import { refreshToken } from '../auth/utils'
 
@@ -15,6 +15,8 @@ export type PaywallEntitlementResult = {
   entitlement: 'no-access' | 'has-access' | 'auth-required' | 'pending'
   // Refreshed Authorization header, if a valid one was passed in request
   token?: string | null
+  /** Set only when {@linkcode PaywallEntitlementResult['entitlement']} is 'pending' */
+  paymentId?: string
 }
 
 app.get(
@@ -33,15 +35,12 @@ app.get(
       $url: token?.payload.waUrl || params.$wa || walletAddress,
     }
 
-    const paymentStatus = await hasPayment(
-      env.PUBLISHER_TOOLS_DB,
-      params.url,
-      payer,
-    )
+    const payment = await findPayment(env.PUBLISHER_TOOLS_DB, params.url, payer)
 
     const result: PaywallEntitlementResult = {
-      entitlement: getEntitlement(paymentStatus, !!token),
+      entitlement: getEntitlement(payment, !!token),
       token: token?.jwt,
+      ...(payment && { paymentId: payment.paymentId }),
     }
     if (result.entitlement === 'has-access') {
       header('Cache-Control', 'private, max-age=3600')
@@ -79,10 +78,10 @@ app.get(
 )
 
 function getEntitlement(
-  paymentStatus: Awaited<ReturnType<typeof hasPayment>>,
+  payment: Awaited<ReturnType<typeof findPayment>>,
   hasToken: boolean,
 ): PaywallEntitlementResult['entitlement'] {
-  if (!paymentStatus) return 'no-access'
-  if (paymentStatus === 'created') return 'pending'
+  if (!payment) return 'no-access'
+  if (payment.status === 'created') return 'pending'
   return hasToken ? 'has-access' : 'auth-required'
 }

--- a/api/src/routes/paywall/entitlement.ts
+++ b/api/src/routes/paywall/entitlement.ts
@@ -37,10 +37,12 @@ app.get(
 
     const payment = await findPayment(env.PUBLISHER_TOOLS_DB, params.url, payer)
 
+    const entitlement = getEntitlement(payment, !!token)
+    const paymentId = payment ? payment.paymentId : undefined
     const result: PaywallEntitlementResult = {
-      entitlement: getEntitlement(payment, !!token),
+      entitlement,
       token: token?.jwt,
-      ...(payment && { paymentId: payment.paymentId }),
+      ...(payment && entitlement === 'pending' && { paymentId }),
     }
     if (result.entitlement === 'has-access') {
       header('Cache-Control', 'private, max-age=3600')

--- a/api/src/utils/payments-db.test.ts
+++ b/api/src/utils/payments-db.test.ts
@@ -4,7 +4,7 @@ import { ensureEnd } from '@shared/utils'
 import {
   savePayment,
   getPayment,
-  hasPayment,
+  findPayment,
   setPaymentStatus,
   UNSAFE_devEmptyDatabase,
   hash,
@@ -34,8 +34,8 @@ describe('Paywall Database', () => {
     ).resolves.toMatchObject({ count: 1 })
 
     await expect(
-      hasPayment(DB, mockPayment.url.href, mockPayment.sender),
-    ).resolves.toBe('complete')
+      findPayment(DB, mockPayment.url.href, mockPayment.sender),
+    ).resolves.toEqual({ status: 'complete', paymentId: mockPayment.paymentId })
   })
 
   it('should grant access using the fallback wallet URL if the internal ID changes', async () => {
@@ -45,25 +45,25 @@ describe('Paywall Database', () => {
     ).resolves.toMatchObject({ count: 1 })
 
     await expect(
-      hasPayment(DB, mockPayment.url.href, {
+      findPayment(DB, mockPayment.url.href, {
         ...mockPayment.sender,
         id: 'https://wallet.com/sender2',
       }),
-    ).resolves.toBe('complete')
+    ).resolves.toEqual({ status: 'complete', paymentId: mockPayment.paymentId })
   })
 
   it('should return falsy when a user has not paid for the content', async () => {
     await expect(
-      hasPayment(DB, 'https://myblog.com/other-post', mockPayment.sender),
+      findPayment(DB, 'https://myblog.com/other-post', mockPayment.sender),
     ).resolves.toBeFalsy()
 
     await savePayment(DB, mockPayment)
     await expect(
-      hasPayment(DB, 'https://myblog.com/other-post', mockPayment.sender),
+      findPayment(DB, 'https://myblog.com/other-post', mockPayment.sender),
     ).resolves.toBeFalsy()
 
     await expect(
-      hasPayment(DB, mockPayment.url.href, {
+      findPayment(DB, mockPayment.url.href, {
         id: 'https://wallet.com/stranger',
         $url: 'https://stranger.com',
       }),
@@ -79,26 +79,26 @@ describe('Paywall Database', () => {
     ).resolves.toMatchObject({ count: 1 })
 
     await expect(
-      hasPayment(DB, url.href, {
+      findPayment(DB, url.href, {
         ...mockPayment.sender,
         id: 'https://wallet.com/sender2',
       }),
-    ).resolves.toBe('complete')
+    ).resolves.toEqual({ status: 'complete', paymentId: mockPayment.paymentId })
 
     url.searchParams.set('bar', 'baz')
     await expect(
-      hasPayment(DB, url.href, {
+      findPayment(DB, url.href, {
         ...mockPayment.sender,
         id: 'https://wallet.com/sender2',
       }),
-    ).resolves.toBe('complete')
+    ).resolves.toEqual({ status: 'complete', paymentId: mockPayment.paymentId })
 
     await expect(
-      hasPayment(DB, url.origin + ensureEnd(url.pathname, '/'), {
+      findPayment(DB, url.origin + ensureEnd(url.pathname, '/'), {
         ...mockPayment.sender,
         id: 'https://wallet.com/sender2',
       }),
-    ).resolves.toBe('complete')
+    ).resolves.toEqual({ status: 'complete', paymentId: mockPayment.paymentId })
   })
 
   it('should fetch the full, reconstructed payment record using getPayment', async () => {
@@ -121,14 +121,14 @@ describe('Paywall Database', () => {
     await savePayment(DB, { ...mockPayment, status: 'created' })
 
     await expect(
-      hasPayment(DB, mockPayment.url.href, mockPayment.sender),
-    ).resolves.toBe('created')
+      findPayment(DB, mockPayment.url.href, mockPayment.sender),
+    ).resolves.toEqual({ status: 'created', paymentId: mockPayment.paymentId })
 
     await setPaymentStatus(DB, mockPayment.paymentId, 'complete')
 
     await expect(
-      hasPayment(DB, mockPayment.url.href, mockPayment.sender),
-    ).resolves.toBe('complete')
+      findPayment(DB, mockPayment.url.href, mockPayment.sender),
+    ).resolves.toEqual({ status: 'complete', paymentId: mockPayment.paymentId })
   })
 
   it('should delete the payment records when status is set to failed', async () => {
@@ -142,14 +142,14 @@ describe('Paywall Database', () => {
     await savePayment(DB, mockPayment2)
 
     await expect(
-      hasPayment(DB, mockPayment.url.href, mockPayment.sender),
-    ).resolves.toBe('created')
+      findPayment(DB, mockPayment.url.href, mockPayment.sender),
+    ).resolves.toEqual({ status: 'created', paymentId: mockPayment.paymentId })
 
     const changed = await setPaymentStatus(DB, mockPayment.paymentId, 'failed')
     expect(changed).toBe(true)
 
     await expect(
-      hasPayment(DB, mockPayment.url.href, mockPayment.sender),
+      findPayment(DB, mockPayment.url.href, mockPayment.sender),
     ).resolves.toBeFalsy()
 
     const countByPaymentId = (paymentId: string) =>
@@ -177,14 +177,14 @@ describe('Paywall Database', () => {
   it('should only delete payment records when status is set to failed and not already complete', async () => {
     await savePayment(DB, { ...mockPayment, status: 'complete' })
     await expect(
-      hasPayment(DB, mockPayment.url.href, mockPayment.sender),
-    ).resolves.toBe('complete')
+      findPayment(DB, mockPayment.url.href, mockPayment.sender),
+    ).resolves.toEqual({ status: 'complete', paymentId: mockPayment.paymentId })
 
     const changed = await setPaymentStatus(DB, mockPayment.paymentId, 'failed')
     expect(changed).toBe(false)
     await expect(
-      hasPayment(DB, mockPayment.url.href, mockPayment.sender),
-    ).resolves.toBe('complete')
+      findPayment(DB, mockPayment.url.href, mockPayment.sender),
+    ).resolves.toEqual({ status: 'complete', paymentId: mockPayment.paymentId })
 
     await expect(
       DB.exec(sql`SELECT COUNT(*) as count from paywall_payments`),

--- a/api/src/utils/payments-db.ts
+++ b/api/src/utils/payments-db.ts
@@ -85,11 +85,11 @@ export async function setPaymentStatus(
   return res.meta.changes === 1
 }
 
-export async function hasPayment(
+export async function findPayment(
   db: D1Database,
   url: string,
   payer: Pick<WalletAddressInfo, 'id' | '$url'>,
-): Promise<false | PaymentStatus> {
+): Promise<false | { status: PaymentStatus; paymentId: string }> {
   const normalizedUrl = normalizeUrl(new URL(url))
   const [hashedUrl, hashedPayerWalletAddressId, hashedPayerWalletAddressUrl] =
     await Promise.all([hash(normalizedUrl), hash(payer.id), hash(payer.$url)])
@@ -107,7 +107,10 @@ export async function hasPayment(
     return false
   }
 
-  return res.status === 1 ? 'complete' : 'created'
+  return {
+    status: mapStatusIdToStatus(res.status),
+    paymentId: res.paymentId,
+  }
 }
 
 export async function getPayment(db: D1Database, paymentId: string) {
@@ -212,7 +215,7 @@ interface PaywallPaymentRow {
 /**
  * Represents a raw row inside the 'paywall_payments_meta' table.
  */
-export interface PaywallPaymentMetaRow {
+interface PaywallPaymentMetaRow {
   paymentId: string // Primary key matching paywall_payments.paymentId
   outgoingPaymentId: string
   incomingPaymentId: string


### PR DESCRIPTION
If payment status is `pending` when we're checking entitlement, we want to be able to call `/paywall/paywall-status` API to poll the payment status until it reaches 'complete' or 'failed'. We require the `paymentId` available in that case.

Part of https://github.com/interledger/publisher-tools/pull/727 (unhappy path)