### PR TITLE
refactor(BuilderBackground): pass `actions`, use in banner preview

### DIFF
--- a/frontend/app/components/redesign/components/BuilderBackground.tsx
+++ b/frontend/app/components/redesign/components/BuilderBackground.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { cx } from 'class-variance-authority'
-import { ToolsSecondaryButton } from '@/components/ToolsSecondaryButton'
 
 const DOT_PATTERN_SVG = `<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="6" cy="6" r="2" fill="white" fill-opacity="0.5" /></svg>`
 
@@ -15,15 +14,15 @@ const BrowserDots = () => (
 interface BuilderBackgroundProps {
   className?: string
   children?: React.ReactNode
-  onPreviewClick?: () => void
-  isAnimationDisabled?: boolean
+  actions?: React.ReactNode
+  iframeMode?: boolean
 }
 
 export const BuilderBackground: React.FC<BuilderBackgroundProps> = ({
   className = '',
   children,
-  onPreviewClick,
-  isAnimationDisabled = false,
+  actions,
+  iframeMode = false,
 }) => {
   const createDotPattern = () => {
     return `data:image/svg+xml;base64,${btoa(DOT_PATTERN_SVG)}`
@@ -34,7 +33,7 @@ export const BuilderBackground: React.FC<BuilderBackgroundProps> = ({
       id="builder-background"
       className={cx(
         'bg-silver-100 rounded-[20px] p-md flex flex-col items-center min-h-[600px]',
-        onPreviewClick && 'gap-4xl',
+        actions && 'gap-4xl',
         className,
       )}
       style={{
@@ -43,15 +42,7 @@ export const BuilderBackground: React.FC<BuilderBackgroundProps> = ({
         backgroundSize: '16px 16px',
       }}
     >
-      {onPreviewClick && !isAnimationDisabled && (
-        <ToolsSecondaryButton
-          icon="play"
-          className="w-[130px]"
-          onClick={onPreviewClick}
-        >
-          Preview
-        </ToolsSecondaryButton>
-      )}
+      {actions}
 
       <div
         id="browser-mockup"
@@ -66,7 +57,10 @@ export const BuilderBackground: React.FC<BuilderBackgroundProps> = ({
 
         <div
           id="browser-content"
-          className="flex-1 flex flex-col p-md [container-type:inline-size]"
+          className={cx(
+            'flex-1 flex flex-col [container-type:inline-size]',
+            !iframeMode && 'p-md',
+          )}
         >
           {children}
         </div>

--- a/frontend/app/routes/banner.tsx
+++ b/frontend/app/routes/banner.tsx
@@ -280,8 +280,17 @@ export default function Banner() {
                     className="w-full mx-auto xl:mx-0 xl:sticky xl:top-md xl:self-start xl:flex-shrink-0 xl:w-[504px] h-fit"
                   >
                     <BuilderBackground
-                      onPreviewClick={handlePreviewClick}
-                      isAnimationDisabled={isAnimationDisabled}
+                      actions={
+                        !isAnimationDisabled && (
+                          <ToolsSecondaryButton
+                            icon="play"
+                            className="w-[130px]"
+                            onClick={handlePreviewClick}
+                          >
+                            Preview
+                          </ToolsSecondaryButton>
+                        )
+                      }
                     >
                       <BannerPreview ref={bannerRef} cdnUrl={snap.cdnUrl} />
                     </BuilderBackground>


### PR DESCRIPTION
Extracted from https://github.com/interledger/publisher-tools/pull/746

Makes BuilderBackground more generic, not tied to specific tools like banner.