### PR TITLE
refactor(frontend): centralize suggested titles

### DIFF
--- a/frontend/app/components/banner/BannerBuilder.tsx
+++ b/frontend/app/components/banner/BannerBuilder.tsx
@@ -9,7 +9,8 @@ import { FontSizeInput } from '@/components/builder/FontSizeInput'
 import { InputFieldset } from '@/components/builder/InputFieldset'
 import { TitleInput } from '@/components/builder/TitleInput'
 import BuilderAccordion from '@/components/BuilderAccordion'
-import { BANNER_FONT_SIZE_MAP, FONT_FAMILY_OPTIONS } from '@shared/types'
+import { BANNER_FONT_SIZE_MAP, FONT_FAMILY_OPTIONS, TOOL_BANNER } from '@shared/types'
+import { SUGGESTED_TITLES } from '~/lib/presets'
 import {
   SVGAnimation,
   SVGColorPicker,
@@ -30,13 +31,7 @@ interface Props {
 }
 
 const config = {
-  suggestedTitles: [
-    'How to support?',
-    'Fund me',
-    'Pay as you browse',
-    'Easy donate',
-    'Support my work',
-  ],
+  suggestedTitles: SUGGESTED_TITLES[TOOL_BANNER]!,
   titleHelpText: 'Strong message to help people engage with Web Monetization',
   titleMaxLength: 60,
   messageLabel: 'Banner message',

--- a/frontend/app/components/banner/BannerBuilder.tsx
+++ b/frontend/app/components/banner/BannerBuilder.tsx
@@ -9,8 +9,8 @@ import { FontSizeInput } from '@/components/builder/FontSizeInput'
 import { InputFieldset } from '@/components/builder/InputFieldset'
 import { TitleInput } from '@/components/builder/TitleInput'
 import BuilderAccordion from '@/components/BuilderAccordion'
-import { BANNER_FONT_SIZE_MAP, FONT_FAMILY_OPTIONS, TOOL_BANNER } from '@shared/types'
-import { SUGGESTED_TITLES } from '~/lib/presets'
+import { BANNER_FONT_SIZE_MAP, FONT_FAMILY_OPTIONS } from '@shared/types'
+import { BANNER_SUGGESTED_TITLES } from '~/lib/presets'
 import {
   SVGAnimation,
   SVGColorPicker,
@@ -31,7 +31,7 @@ interface Props {
 }
 
 const config = {
-  suggestedTitles: SUGGESTED_TITLES[TOOL_BANNER]!,
+  suggestedTitles: BANNER_SUGGESTED_TITLES,
   titleHelpText: 'Strong message to help people engage with Web Monetization',
   titleMaxLength: 60,
   messageLabel: 'Banner message',

--- a/frontend/app/components/banner/BannerBuilder.tsx
+++ b/frontend/app/components/banner/BannerBuilder.tsx
@@ -10,7 +10,6 @@ import { InputFieldset } from '@/components/builder/InputFieldset'
 import { TitleInput } from '@/components/builder/TitleInput'
 import BuilderAccordion from '@/components/BuilderAccordion'
 import { BANNER_FONT_SIZE_MAP, FONT_FAMILY_OPTIONS } from '@shared/types'
-import { BANNER_SUGGESTED_TITLES } from '~/lib/presets'
 import {
   SVGAnimation,
   SVGColorPicker,
@@ -23,6 +22,7 @@ import { BannerAnimationSelector } from '~/components/banner/BannerAnimationSele
 import { BannerPositionSelector } from '~/components/banner/BannerPositionSelector'
 import { BannerThumbnailSelector } from '~/components/banner/BannerThumbnailSelector'
 import { useBuilderSectionHandlers } from '~/hooks/useBuilderSectionHandlers'
+import { BANNER_SUGGESTED_TITLES } from '~/lib/presets'
 import { useBannerProfile } from '~/stores/banner-store'
 import type { BuilderSection } from '~/stores/uiStore'
 

--- a/frontend/app/components/paywall/PaywallBuilder.tsx
+++ b/frontend/app/components/paywall/PaywallBuilder.tsx
@@ -15,8 +15,10 @@ import {
   PAYWALL_DESCRIPTION_MAX_LENGTH,
   PAYWALL_FONT_SIZE_MAP,
   PAYWALL_TITLE_MAX_LENGTH,
+  TOOL_PAYWALL,
 } from '@shared/types'
 import { SVGColorPicker, SVGRoundedCorner, SVGText } from '~/assets/svg'
+import { SUGGESTED_TITLES } from '~/lib/presets'
 import { useBuilderSectionHandlers } from '~/hooks/useBuilderSectionHandlers'
 import { usePaywallProfile } from '~/stores/paywall-store'
 import type { BuilderSection } from '~/stores/uiStore'
@@ -27,12 +29,7 @@ interface Props {
 }
 
 const config = {
-  suggestedTitles: [
-    'Finish reading this story',
-    'Keep reading',
-    'Unlock full article',
-    'Support this piece',
-  ],
+  suggestedTitles: SUGGESTED_TITLES[TOOL_PAYWALL]!,
   titleHelpText: 'Short and direct works best.',
   titleMaxLength: PAYWALL_TITLE_MAX_LENGTH,
 

--- a/frontend/app/components/paywall/PaywallBuilder.tsx
+++ b/frontend/app/components/paywall/PaywallBuilder.tsx
@@ -17,8 +17,8 @@ import {
   PAYWALL_TITLE_MAX_LENGTH,
 } from '@shared/types'
 import { SVGColorPicker, SVGRoundedCorner, SVGText } from '~/assets/svg'
-import { PAYWALL_SUGGESTED_TITLES } from '~/lib/presets'
 import { useBuilderSectionHandlers } from '~/hooks/useBuilderSectionHandlers'
+import { PAYWALL_SUGGESTED_TITLES } from '~/lib/presets'
 import { usePaywallProfile } from '~/stores/paywall-store'
 import type { BuilderSection } from '~/stores/uiStore'
 import { PaywallColorsSelector } from './PaywallColorsSelector'

--- a/frontend/app/components/paywall/PaywallBuilder.tsx
+++ b/frontend/app/components/paywall/PaywallBuilder.tsx
@@ -15,10 +15,9 @@ import {
   PAYWALL_DESCRIPTION_MAX_LENGTH,
   PAYWALL_FONT_SIZE_MAP,
   PAYWALL_TITLE_MAX_LENGTH,
-  TOOL_PAYWALL,
 } from '@shared/types'
 import { SVGColorPicker, SVGRoundedCorner, SVGText } from '~/assets/svg'
-import { SUGGESTED_TITLES } from '~/lib/presets'
+import { PAYWALL_SUGGESTED_TITLES } from '~/lib/presets'
 import { useBuilderSectionHandlers } from '~/hooks/useBuilderSectionHandlers'
 import { usePaywallProfile } from '~/stores/paywall-store'
 import type { BuilderSection } from '~/stores/uiStore'
@@ -29,7 +28,7 @@ interface Props {
 }
 
 const config = {
-  suggestedTitles: SUGGESTED_TITLES[TOOL_PAYWALL]!,
+  suggestedTitles: PAYWALL_SUGGESTED_TITLES,
   titleHelpText: 'Short and direct works best.',
   titleMaxLength: PAYWALL_TITLE_MAX_LENGTH,
 

--- a/frontend/app/components/redesign/components/builder/TitleInput.tsx
+++ b/frontend/app/components/redesign/components/builder/TitleInput.tsx
@@ -5,7 +5,7 @@ import PillRadioListItem from '../PillRadioListItem'
 interface Props {
   value: string
   onChange: (title: string) => void
-  suggestions: string[]
+  suggestions: readonly string[]
   maxLength: number
   helpText?: string
 }

--- a/frontend/app/components/widget/WidgetBuilder.tsx
+++ b/frontend/app/components/widget/WidgetBuilder.tsx
@@ -10,7 +10,6 @@ import { InputFieldset } from '@/components/builder/InputFieldset'
 import { TitleInput } from '@/components/builder/TitleInput'
 import BuilderAccordion from '@/components/BuilderAccordion'
 import { FONT_FAMILY_OPTIONS, WIDGET_FONT_SIZE_MAP } from '@shared/types'
-import { WIDGET_SUGGESTED_TITLES } from '~/lib/presets'
 import {
   SVGColorPicker,
   SVGHeaderPosition,
@@ -19,6 +18,7 @@ import {
 } from '~/assets/svg'
 import { WidgetPositionSelector } from '~/components/widget/WidgetPositionSelector'
 import { useBuilderSectionHandlers } from '~/hooks/useBuilderSectionHandlers'
+import { WIDGET_SUGGESTED_TITLES } from '~/lib/presets'
 import type { BuilderSection } from '~/stores/uiStore'
 import { useWidgetProfile } from '~/stores/widget-store'
 

--- a/frontend/app/components/widget/WidgetBuilder.tsx
+++ b/frontend/app/components/widget/WidgetBuilder.tsx
@@ -9,8 +9,8 @@ import { FontSizeInput } from '@/components/builder/FontSizeInput'
 import { InputFieldset } from '@/components/builder/InputFieldset'
 import { TitleInput } from '@/components/builder/TitleInput'
 import BuilderAccordion from '@/components/BuilderAccordion'
-import { FONT_FAMILY_OPTIONS, TOOL_WIDGET, WIDGET_FONT_SIZE_MAP } from '@shared/types'
-import { SUGGESTED_TITLES } from '~/lib/presets'
+import { FONT_FAMILY_OPTIONS, WIDGET_FONT_SIZE_MAP } from '@shared/types'
+import { WIDGET_SUGGESTED_TITLES } from '~/lib/presets'
 import {
   SVGColorPicker,
   SVGHeaderPosition,
@@ -27,7 +27,7 @@ interface Props {
 }
 
 const config = {
-  suggestedTitles: SUGGESTED_TITLES[TOOL_WIDGET]!,
+  suggestedTitles: WIDGET_SUGGESTED_TITLES,
   titleHelpText: 'Message to encourage one-time payments',
   titleMaxLength: 30,
   messageLabel: 'Widget message',

--- a/frontend/app/components/widget/WidgetBuilder.tsx
+++ b/frontend/app/components/widget/WidgetBuilder.tsx
@@ -9,7 +9,8 @@ import { FontSizeInput } from '@/components/builder/FontSizeInput'
 import { InputFieldset } from '@/components/builder/InputFieldset'
 import { TitleInput } from '@/components/builder/TitleInput'
 import BuilderAccordion from '@/components/BuilderAccordion'
-import { FONT_FAMILY_OPTIONS, WIDGET_FONT_SIZE_MAP } from '@shared/types'
+import { FONT_FAMILY_OPTIONS, TOOL_WIDGET, WIDGET_FONT_SIZE_MAP } from '@shared/types'
+import { SUGGESTED_TITLES } from '~/lib/presets'
 import {
   SVGColorPicker,
   SVGHeaderPosition,
@@ -26,13 +27,7 @@ interface Props {
 }
 
 const config = {
-  suggestedTitles: [
-    'Support this content',
-    'Make a payment',
-    'Contribute now',
-    'Help support',
-    'One-time donation',
-  ],
+  suggestedTitles: SUGGESTED_TITLES[TOOL_WIDGET]!,
   titleHelpText: 'Message to encourage one-time payments',
   titleMaxLength: 30,
   messageLabel: 'Widget message',

--- a/frontend/app/lib/presets.ts
+++ b/frontend/app/lib/presets.ts
@@ -1,0 +1,29 @@
+import { TOOL_BANNER, TOOL_PAYWALL, TOOL_WIDGET } from '@shared/types'
+import type { Tool } from '@shared/types'
+
+export const SUGGESTED_TITLES: Partial<Record<Tool, readonly string[]>> = {
+  [TOOL_BANNER]: [
+    'How to support?',
+    'Fund me',
+    'Pay as you browse',
+    'Easy donate',
+    'Support my work',
+  ],
+  [TOOL_WIDGET]: [
+    'Support this content',
+    'Make a payment',
+    'Contribute now',
+    'Help support',
+    'One-time donation',
+  ],
+  [TOOL_PAYWALL]: [
+    'Finish reading this story',
+    'Keep reading',
+    'Unlock full article',
+    'Support this piece',
+  ],
+}
+
+export const ALL_SUGGESTED_TITLES = new Set<string>(
+  Object.values(SUGGESTED_TITLES).flat(),
+)

--- a/frontend/app/lib/presets.ts
+++ b/frontend/app/lib/presets.ts
@@ -1,29 +1,28 @@
-import { TOOL_BANNER, TOOL_PAYWALL, TOOL_WIDGET } from '@shared/types'
-import type { Tool } from '@shared/types'
+export const BANNER_SUGGESTED_TITLES = [
+  'How to support?',
+  'Fund me',
+  'Pay as you browse',
+  'Easy donate',
+  'Support my work',
+] as const
 
-export const SUGGESTED_TITLES: Partial<Record<Tool, readonly string[]>> = {
-  [TOOL_BANNER]: [
-    'How to support?',
-    'Fund me',
-    'Pay as you browse',
-    'Easy donate',
-    'Support my work',
-  ],
-  [TOOL_WIDGET]: [
-    'Support this content',
-    'Make a payment',
-    'Contribute now',
-    'Help support',
-    'One-time donation',
-  ],
-  [TOOL_PAYWALL]: [
-    'Finish reading this story',
-    'Keep reading',
-    'Unlock full article',
-    'Support this piece',
-  ],
-}
+export const WIDGET_SUGGESTED_TITLES = [
+  'Support this content',
+  'Make a payment',
+  'Contribute now',
+  'Help support',
+  'One-time donation',
+] as const
 
-export const ALL_SUGGESTED_TITLES = new Set<string>(
-  Object.values(SUGGESTED_TITLES).flat(),
-)
+export const PAYWALL_SUGGESTED_TITLES = [
+  'Finish reading this story',
+  'Keep reading',
+  'Unlock full article',
+  'Support this piece',
+] as const
+
+export const ALL_SUGGESTED_TITLES = new Set<string>([
+  ...BANNER_SUGGESTED_TITLES,
+  ...WIDGET_SUGGESTED_TITLES,
+  ...PAYWALL_SUGGESTED_TITLES,
+])

--- a/frontend/app/routes/paywall.tsx
+++ b/frontend/app/routes/paywall.tsx
@@ -28,7 +28,7 @@ import { useSaveProfile } from '~/hooks/useSaveProfile'
 import { useScrollToWalletAddress } from '~/hooks/useScrollToWalletAddress'
 import { useToolWallet } from '~/hooks/useToolWallet'
 import {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+   
   actions,
   hydrateProfilesFromStorage,
   hydrateSnapshotsFromStorage,

--- a/frontend/app/routes/paywall.tsx
+++ b/frontend/app/routes/paywall.tsx
@@ -28,7 +28,6 @@ import { useSaveProfile } from '~/hooks/useSaveProfile'
 import { useScrollToWalletAddress } from '~/hooks/useScrollToWalletAddress'
 import { useToolWallet } from '~/hooks/useToolWallet'
 import {
-   
   actions,
   hydrateProfilesFromStorage,
   hydrateSnapshotsFromStorage,


### PR DESCRIPTION
A part of #718

### Change
Move the tool `suggestedTitles` arrays out of each builder's inline config and into a single file `app/lib/presets.ts`. Builders now import `SUGGESTED_TITLES[TOOL_*]`

Sets up a follow-up analytics change (#718)  to distinguish clicked-preset titles from free-typed text