### PR TITLE
refactor(app): use different layouts for routes

### DIFF
--- a/frontend/app/layouts/MainLayout.tsx
+++ b/frontend/app/layouts/MainLayout.tsx
@@ -1,0 +1,18 @@
+import { Outlet } from 'react-router'
+import { Header, Footer } from '@/components'
+import { I18nProvider } from '~/i18n/context'
+import { UIProvider } from '~/stores/uiStore'
+
+export default function MainLayout() {
+  return (
+    <I18nProvider>
+      <UIProvider>
+        <Header />
+        <main className="flex-grow flex flex-col">
+          <Outlet />
+        </main>
+        <Footer />
+      </UIProvider>
+    </I18nProvider>
+  )
+}

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -10,11 +10,8 @@ import {
   type LinksFunction,
   type MetaFunction,
 } from 'react-router'
-import { Header, Footer } from '@/components'
 import { APP_URL, UMAMI_HOST, UMAMI_WEBSITE_ID } from '@shared/defines'
 import faviconSvg from '~/assets/images/favicon.svg?url'
-import { I18nProvider } from '~/i18n/context'
-import { UIProvider } from '~/stores/uiStore'
 import stylesheet from '~/tailwind.css?url'
 import { XCircle } from './components/icons.js'
 import { Button } from './components/index.js'
@@ -43,15 +40,7 @@ export default function App() {
         )}
       </head>
       <body className="h-screen bg-interface-bg-main flex flex-col">
-        <I18nProvider>
-          <UIProvider>
-            <Header />
-            <main className="flex-grow flex flex-col">
-              <Outlet />
-            </main>
-            <Footer />
-          </UIProvider>
-        </I18nProvider>
+        <Outlet />
         <ScrollRestoration />
         <Scripts crossOrigin="" />
       </body>

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -1,17 +1,24 @@
-import { type RouteConfig, index, route } from '@react-router/dev/routes'
+import {
+  type RouteConfig,
+  index,
+  layout,
+  route,
+} from '@react-router/dev/routes'
 
 export default [
   // Root index route
-  index('routes/_index.tsx'),
-  // Tool routes
-  route('banner/', 'routes/banner.tsx'),
-  route('link-tag/', 'routes/link-tag.tsx'),
+  layout('./layouts/MainLayout.tsx', [
+    index('routes/_index.tsx'),
+    // Tool routes
+    route('banner/', 'routes/banner.tsx'),
+    route('link-tag/', 'routes/link-tag.tsx'),
+    route('prob-revshare/', 'routes/prob-revshare.tsx'),
+    route('widget/', 'routes/widget.tsx'),
+    route('paywall/', 'routes/paywall.tsx'),
+    route('offerwall/', 'routes/offerwall.tsx'),
+  ]),
   route('payment-confirmation/', 'routes/payment-confirmation.tsx'),
-  route('prob-revshare/', 'routes/prob-revshare.tsx'),
-  route('widget/', 'routes/widget.tsx'),
-  route('paywall/', 'routes/paywall.tsx'),
   route('paywall/preview/', 'routes/paywall-preview.tsx'),
-  route('offerwall/', 'routes/offerwall.tsx'),
   // API routes
   route('api/grant/:type', 'routes/api.grant.$type.ts'),
   route('api/profiles', 'routes/api.profiles.ts'),

--- a/frontend/app/routes/paywall-preview.tsx
+++ b/frontend/app/routes/paywall-preview.tsx
@@ -9,11 +9,6 @@ export default function PaywallPreview() {
   const [profile, setProfile] = useState(() => getDefaultProfile('paywall'))
   const [isLoaded, setIsLoaded] = useState(false)
 
-  useEffect(() => {
-    document.querySelector('body > header')?.remove()
-    document.querySelector('body > footer')?.remove()
-  }, [])
-
   const NAME = 'wm-paywall'
   useEffect(() => {
     const load = async () => {


### PR DESCRIPTION
Remove header/footer from paywall-preview and payment-confirmation pages, by using MainLayout only on pages that need header/footer.