### PR TITLE
feat(InputFieldNumeric): add numeric input; use in paywall editor

### DIFF
--- a/frontend/app/components/paywall/PaywallPlacementBuilder.tsx
+++ b/frontend/app/components/paywall/PaywallPlacementBuilder.tsx
@@ -1,9 +1,9 @@
 import { useId } from 'react'
 import { cx } from 'class-variance-authority'
+import { InputFieldNumeric } from '@/components/InputFieldNumeric'
 import type { PaywallProfile } from '@shared/types'
 import { useTranslation } from '~/i18n/useTranslation'
 import { usePaywallProfile } from '~/stores/paywall-store'
-import { InputField } from '../redesign/components'
 
 export function PaywallPlacementBuilder() {
   const [snap, profile] = usePaywallProfile()
@@ -43,6 +43,12 @@ export function PaywallPlacementBuilder() {
 }
 
 type CoverageAmount = PaywallProfile['behavior']['coverage']['value']
+const coverageOptions: { value: CoverageAmount; text: string }[] = [
+  { value: 25, text: '25%' },
+  { value: 50, text: '50%' },
+  { value: 75, text: '75%' },
+  { value: 100, text: 'Full page' },
+]
 function PaywallCoverageInput({
   value,
   onChange,
@@ -52,12 +58,6 @@ function PaywallCoverageInput({
 }) {
   const id = useId()
   const t = useTranslation('paywall')
-  const options: { value: CoverageAmount; text: string }[] = [
-    { value: 25, text: '25%' },
-    { value: 50, text: '50%' },
-    { value: 75, text: '75%' },
-    { value: 100, text: 'Full page' },
-  ]
 
   return (
     <fieldset className="space-y-2xs">
@@ -65,7 +65,7 @@ function PaywallCoverageInput({
         {t('input.coverage.label')}
       </legend>
       <div className="flex gap-1 w-fit p-1.5 rounded-sm border border-field-border bg-field-bg-disabled">
-        {options.map(({ value: val, text }) => (
+        {coverageOptions.map(({ value: val, text }) => (
           <label
             key={val}
             className={cx(
@@ -98,19 +98,17 @@ function PaywallDelayInput({
 }) {
   const t = useTranslation('paywall')
   return (
-    <InputField
+    <InputFieldNumeric
       label={t('input.delay.label')}
       inputMode="decimal"
       value={value}
-      onChange={(ev) => {
-        const value = Number(ev.currentTarget.value)
-        if (!Number.isNaN(value) && Number.isInteger(value) && value >= 0) {
-          onChange(value)
-        }
-      }}
+      onChange={onChange}
       helpText={t('input.delay.hint')}
       className="max-w-56"
       addonAfter={t('input.delay.suffix')}
+      min={0}
+      max={15}
+      precision={1}
     />
   )
 }

--- a/frontend/app/components/paywall/PaywallPriceBuilder.tsx
+++ b/frontend/app/components/paywall/PaywallPriceBuilder.tsx
@@ -30,7 +30,6 @@ export function PaywallPriceBuilder() {
           label={t('input.price.label')}
           value={snap.price.value}
           onChange={(value) => {
-            console.log('onChange', { value })
             profile.price.value = String(value)
           }}
           helpText={t('input.price.hint', { currency })}

--- a/frontend/app/components/paywall/PaywallPriceBuilder.tsx
+++ b/frontend/app/components/paywall/PaywallPriceBuilder.tsx
@@ -1,12 +1,13 @@
+import { InputFieldNumeric } from '@/components/InputFieldNumeric'
 import { getCurrencySymbol } from '@c/utils'
 import { useTranslation } from '~/i18n/useTranslation'
 import { usePaywallProfile } from '~/stores/paywall-store'
-import { InputField } from '../redesign/components'
 
 export function PaywallPriceBuilder() {
   const [snap, profile] = usePaywallProfile()
   const t = useTranslation('paywall')
 
+  const precision = 2 // TODO: get from walletAddressInfo
   const currency = snap.price.currency
   const currencySymbol = getCurrencySymbol(currency)
 
@@ -25,15 +26,18 @@ export function PaywallPriceBuilder() {
           {t('inputgroup.price.desc')}
         </p>
 
-        <InputField
+        <InputFieldNumeric
           label={t('input.price.label')}
           value={snap.price.value}
-          onChange={(ev) => {
-            profile.price.value = ev.currentTarget.value
+          onChange={(value) => {
+            console.log('onChange', { value })
+            profile.price.value = String(value)
           }}
           helpText={t('input.price.hint', { currency })}
           addonBefore={currencySymbol}
           addonClassName="inline-block pr-2"
+          precision={precision}
+          min={Math.pow(10, -precision)}
         />
       </fieldset>
     </div>

--- a/frontend/app/components/redesign/components/InputFieldNumeric.tsx
+++ b/frontend/app/components/redesign/components/InputFieldNumeric.tsx
@@ -1,0 +1,84 @@
+import { type ComponentProps, useRef } from 'react'
+import { InputField } from './InputField'
+
+type InputFieldProps = ComponentProps<typeof InputField>
+interface Props extends Omit<InputFieldProps, 'onChange'> {
+  onChange: (value: number) => void
+  min: number
+  max?: number
+  /** Max floating point digits allowed. Set to 0 to allow only integers. */
+  precision?: number
+  value?: string | number
+}
+
+export const InputFieldNumeric = ({
+  value,
+  onChange,
+  min,
+  max,
+  precision = 0,
+  ...props
+}: Props) => {
+  const ref = useRef<HTMLInputElement>(null)
+  const setValue = (value: string) => {
+    ref.current!.value = value
+  }
+
+  const handleChange: InputFieldProps['onChange'] = (ev) => {
+    const val = ev.currentTarget.value.trim()
+    if (!val) return
+    let value = Number(val)
+    if (Number.isFinite(value)) {
+      if (typeof min === 'number' && value < min) value = min
+      onChange(Number(value.toFixed(precision)))
+    }
+  }
+
+  const handleBlur: InputFieldProps['onBlur'] = (ev) => {
+    const value = (() => {
+      const val = Number(ev.currentTarget.value)
+      if (typeof min === 'number' && val < min) return min
+      if (typeof max === 'number' && val > max) return max
+      return Number(val.toFixed(precision))
+    })()
+    setValue(value.toString())
+    onChange(value)
+  }
+
+  const handleKeyDown: InputFieldProps['onKeyDown'] = (ev) => {
+    if (ev.currentTarget.value.includes('.') && ev.key === '.') {
+      return ev.preventDefault()
+    }
+    if (isNonNumericKey(ev)) return ev.preventDefault()
+    if (ev.key !== 'ArrowUp' && ev.key !== 'ArrowDown') return
+
+    const delta = (ev.key === 'ArrowUp' ? 1 : -1) * Math.pow(10, -precision)
+    const newValue = Number(
+      (Number(ref.current!.value) + delta).toFixed(precision),
+    )
+    if (typeof min === 'number' && newValue < min) return
+    if (typeof max === 'number' && newValue > max) return
+    setValue(newValue.toFixed(precision))
+    onChange(newValue)
+  }
+
+  return (
+    <InputField
+      defaultValue={value}
+      onChange={handleChange}
+      inputMode="decimal"
+      onKeyDown={handleKeyDown}
+      onBlur={handleBlur}
+      ref={ref}
+      {...props}
+    />
+  )
+}
+
+function isNonNumericKey(ev: React.KeyboardEvent<HTMLInputElement>) {
+  return (
+    ev.key.length === 1 && !/^[\d.]$/.test(ev.key) && !ev.ctrlKey && !ev.metaKey
+  )
+}
+
+InputFieldNumeric.displayName = 'InputFieldNumeric'

--- a/frontend/app/components/redesign/components/InputFieldNumeric.tsx
+++ b/frontend/app/components/redesign/components/InputFieldNumeric.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps, useRef } from 'react'
+import { type ComponentProps, useEffect, useRef } from 'react'
 import { InputField } from './InputField'
 
 type InputFieldProps = ComponentProps<typeof InputField>
@@ -61,6 +61,12 @@ export const InputFieldNumeric = ({
     setValue(newValue.toFixed(precision))
     onChange(newValue)
   }
+
+  useEffect(() => {
+    if (typeof value !== 'undefined') {
+      setValue(value.toString())
+    }
+  }, [value])
 
   return (
     <InputField


### PR DESCRIPTION
Closes https://github.com/interledger/publisher-tools/issues/688
Part of https://github.com/interledger/publisher-tools/issues/670 (story)

Add a `InputFieldNumeric` component based on `InputField`, and use it in paywall editor's price and delay inputs.