### PR TITLE
refactor(frontend): edit icon for profile changes in builder accordion

### DIFF
--- a/frontend/app/components/banner/BannerBuilder.tsx
+++ b/frontend/app/components/banner/BannerBuilder.tsx
@@ -23,7 +23,7 @@ import { BannerPositionSelector } from '~/components/banner/BannerPositionSelect
 import { BannerThumbnailSelector } from '~/components/banner/BannerThumbnailSelector'
 import { useBuilderSectionHandlers } from '~/hooks/useBuilderSectionHandlers'
 import { BANNER_SUGGESTED_TITLES } from '~/lib/presets'
-import { useBannerProfile } from '~/stores/banner-store'
+import { useBannerProfile, useSectionHasChanges } from '~/stores/banner-store'
 import type { BuilderSection } from '~/stores/uiStore'
 
 interface Props {
@@ -52,14 +52,15 @@ export function BannerBuilder({ onRefresh }: Props) {
 }
 
 function ContentBuilder({ onRefresh }: Props) {
-  const { isComplete, isOpen, onClick, onToggle, onDone } =
+  const { isOpen, onClick, onToggle, onDone } =
     useBuilderSectionHandlers('content')
+  const hasChanges = useSectionHasChanges('content')
   const [snap, profile] = useBannerProfile({ sync: true })
 
   return (
     <BuilderAccordion
       title="Content"
-      isComplete={isComplete}
+      hasChanges={hasChanges}
       isOpen={isOpen}
       onClick={onClick}
       onToggle={onToggle}
@@ -97,8 +98,9 @@ function ContentBuilder({ onRefresh }: Props) {
 }
 
 function AppearanceBuilder({ onRefresh }: Props) {
-  const { isComplete, isOpen, onClick, onToggle, onDone } =
+  const { isOpen, onClick, onToggle, onDone } =
     useBuilderSectionHandlers('appearance')
+  const hasChanges = useSectionHasChanges('appearance')
   const [snap, profile] = useBannerProfile()
 
   const defaultFontIndex = FONT_FAMILY_OPTIONS.findIndex(
@@ -108,7 +110,7 @@ function AppearanceBuilder({ onRefresh }: Props) {
   return (
     <BuilderAccordion
       title="Appearance"
-      isComplete={isComplete}
+      hasChanges={hasChanges}
       isOpen={isOpen}
       onClick={onClick}
       onToggle={onToggle}

--- a/frontend/app/components/offerwall/OfferwallBuilder.tsx
+++ b/frontend/app/components/offerwall/OfferwallBuilder.tsx
@@ -16,7 +16,6 @@ import {
 import { SVGColorPicker, SVGRoundedCorner, SVGText } from '~/assets/svg'
 import { useOfferwallProfile } from '~/stores/offerwall-store'
 import { toolActions } from '~/stores/toolStore'
-import { useUIState } from '~/stores/uiStore'
 
 interface Props {
   onRefresh: () => void
@@ -31,7 +30,6 @@ export function OfferwallBuilder({ onRefresh }: Props) {
 }
 
 function AppearanceBuilder({ onRefresh }: Props) {
-  const uiState = useUIState()
   const [snap, profile] = useOfferwallProfile()
   const defaultFontIndex = FONT_FAMILY_OPTIONS.findIndex(
     (option) => option === snap.font.name,
@@ -46,12 +44,7 @@ function AppearanceBuilder({ onRefresh }: Props) {
   }, [])
 
   return (
-    <BuilderAccordion
-      title="Appearance"
-      isComplete={uiState.appearanceComplete}
-      onRefresh={onRefresh}
-      isOpen
-    >
+    <BuilderAccordion title="Appearance" onRefresh={onRefresh} isOpen>
       <InputFieldset label="Text" icon={<SVGText className="w-5 h-5" />}>
         <ToolsDropdown
           label="Font Family"

--- a/frontend/app/components/paywall/PaywallBuilder.tsx
+++ b/frontend/app/components/paywall/PaywallBuilder.tsx
@@ -19,7 +19,7 @@ import {
 import { SVGColorPicker, SVGRoundedCorner, SVGText } from '~/assets/svg'
 import { useBuilderSectionHandlers } from '~/hooks/useBuilderSectionHandlers'
 import { PAYWALL_SUGGESTED_TITLES } from '~/lib/presets'
-import { usePaywallProfile } from '~/stores/paywall-store'
+import { usePaywallProfile, useSectionHasChanges } from '~/stores/paywall-store'
 import type { BuilderSection } from '~/stores/uiStore'
 import { PaywallColorsSelector } from './PaywallColorsSelector'
 
@@ -52,14 +52,15 @@ export function PaywallBuilder({ onRefresh }: Props) {
 }
 
 function ContentBuilder({ onRefresh }: Props) {
-  const { isComplete, isOpen, onClick, onToggle, onDone } =
+  const { isOpen, onClick, onToggle, onDone } =
     useBuilderSectionHandlers('content')
+  const hasChanges = useSectionHasChanges('content')
   const [snap, profile] = usePaywallProfile({ sync: true })
 
   return (
     <BuilderAccordion
       title="Content"
-      isComplete={isComplete}
+      hasChanges={hasChanges}
       isOpen={isOpen}
       onClick={onClick}
       onToggle={onToggle}
@@ -114,8 +115,9 @@ function ContentBuilder({ onRefresh }: Props) {
 }
 
 function AppearanceBuilder({ onRefresh }: Props) {
-  const { isComplete, isOpen, onClick, onToggle, onDone } =
+  const { isOpen, onClick, onToggle, onDone } =
     useBuilderSectionHandlers('appearance')
+  const hasChanges = useSectionHasChanges('appearance')
   const [snap, profile] = usePaywallProfile()
 
   const defaultFontIndex = FONT_FAMILY_OPTIONS.findIndex(
@@ -125,7 +127,7 @@ function AppearanceBuilder({ onRefresh }: Props) {
   return (
     <BuilderAccordion
       title="Appearance"
-      isComplete={isComplete}
+      hasChanges={hasChanges}
       isOpen={isOpen}
       onClick={onClick}
       onToggle={onToggle}

--- a/frontend/app/components/paywall/PaywallBuilder.tsx
+++ b/frontend/app/components/paywall/PaywallBuilder.tsx
@@ -20,7 +20,7 @@ import { SVGColorPicker, SVGRoundedCorner, SVGText } from '~/assets/svg'
 import { useBuilderSectionHandlers } from '~/hooks/useBuilderSectionHandlers'
 import { useTranslation } from '~/i18n/useTranslation'
 import { PAYWALL_SUGGESTED_TITLES } from '~/lib/presets'
-import { usePaywallProfile } from '~/stores/paywall-store'
+import { usePaywallProfile, useSectionHasChanges } from '~/stores/paywall-store'
 import type { BuilderSection } from '~/stores/uiStore'
 import { PaywallColorsSelector } from './PaywallColorsSelector'
 
@@ -39,14 +39,15 @@ export function PaywallBuilder({ onRefresh }: Props) {
 
 function ContentBuilder({ onRefresh }: Props) {
   const t = useTranslation('paywall')
-  const { isComplete, isOpen, onClick, onToggle, onDone } =
+  const { isOpen, onClick, onToggle, onDone } =
     useBuilderSectionHandlers('content')
+  const hasChanges = useSectionHasChanges('content')
   const [snap, profile] = usePaywallProfile({ sync: true })
 
   return (
     <BuilderAccordion
       title="Content"
-      isComplete={isComplete}
+      hasChanges={hasChanges}
       isOpen={isOpen}
       onClick={onClick}
       onToggle={onToggle}
@@ -101,8 +102,9 @@ function ContentBuilder({ onRefresh }: Props) {
 }
 
 function AppearanceBuilder({ onRefresh }: Props) {
-  const { isComplete, isOpen, onClick, onToggle, onDone } =
+  const { isOpen, onClick, onToggle, onDone } =
     useBuilderSectionHandlers('appearance')
+  const hasChanges = useSectionHasChanges('appearance')
   const [snap, profile] = usePaywallProfile()
 
   const defaultFontIndex = FONT_FAMILY_OPTIONS.findIndex(
@@ -112,7 +114,7 @@ function AppearanceBuilder({ onRefresh }: Props) {
   return (
     <BuilderAccordion
       title="Appearance"
-      isComplete={isComplete}
+      hasChanges={hasChanges}
       isOpen={isOpen}
       onClick={onClick}
       onToggle={onToggle}

--- a/frontend/app/components/redesign/components/BuilderAccordion.tsx
+++ b/frontend/app/components/redesign/components/BuilderAccordion.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { cx } from 'class-variance-authority'
-import { SVGArrowCollapse, SVGGreenVector } from '@/assets'
+import { SVGArrowCollapse, SVGEdit } from '@/assets'
 import { ToolsSecondaryButton, Divider } from '@/components'
 import { Heading5 } from '@/typography'
 import { GhostButton } from './GhostButton'
@@ -9,7 +9,7 @@ interface Props {
   title: string
   onRefresh: () => void
   onDone?: () => void
-  isComplete?: boolean
+  hasChanges?: boolean
   isOpen?: boolean
   onClick?: (isOpen: boolean) => void
   onToggle?: (e: React.SyntheticEvent<HTMLDetailsElement>) => void
@@ -18,7 +18,7 @@ interface Props {
 
 export const BuilderAccordion: React.FC<Props> = ({
   title,
-  isComplete = false,
+  hasChanges = false,
   isOpen = false,
   onClick,
   onRefresh,
@@ -50,7 +50,12 @@ export const BuilderAccordion: React.FC<Props> = ({
         )}
       >
         <div className="flex gap-xs items-center">
-          {isComplete && !isOpen && <SVGGreenVector className="w-6 h-[18px]" />}
+          {hasChanges && !isOpen && (
+            <>
+              <span className="sr-only">Edited</span>
+              <SVGEdit className="w-6 h-6 text-text-secondary" />
+            </>
+          )}
           <Heading5>{title}</Heading5>
         </div>
 

--- a/frontend/app/components/widget/WidgetBuilder.tsx
+++ b/frontend/app/components/widget/WidgetBuilder.tsx
@@ -20,7 +20,7 @@ import { WidgetPositionSelector } from '~/components/widget/WidgetPositionSelect
 import { useBuilderSectionHandlers } from '~/hooks/useBuilderSectionHandlers'
 import { WIDGET_SUGGESTED_TITLES } from '~/lib/presets'
 import type { BuilderSection } from '~/stores/uiStore'
-import { useWidgetProfile } from '~/stores/widget-store'
+import { useSectionHasChanges, useWidgetProfile } from '~/stores/widget-store'
 
 interface Props {
   onRefresh: (section: BuilderSection) => void
@@ -48,14 +48,15 @@ export function WidgetBuilder({ onRefresh }: Props) {
 }
 
 function ContentBuilder({ onRefresh }: Props) {
-  const { isComplete, isOpen, onClick, onToggle, onDone } =
+  const { isOpen, onClick, onToggle, onDone } =
     useBuilderSectionHandlers('content')
+  const hasChanges = useSectionHasChanges('content')
   const [snap, profile] = useWidgetProfile({ sync: true })
 
   return (
     <BuilderAccordion
       title="Content"
-      isComplete={isComplete}
+      hasChanges={hasChanges}
       isOpen={isOpen}
       onClick={onClick}
       onToggle={onToggle}
@@ -93,8 +94,9 @@ function ContentBuilder({ onRefresh }: Props) {
 }
 
 function AppearanceBuilder({ onRefresh }: Props) {
-  const { isComplete, isOpen, onClick, onToggle, onDone } =
+  const { isOpen, onClick, onToggle, onDone } =
     useBuilderSectionHandlers('appearance')
+  const hasChanges = useSectionHasChanges('appearance')
   const [snap, profile] = useWidgetProfile()
 
   const defaultFontIndex = FONT_FAMILY_OPTIONS.findIndex(
@@ -104,7 +106,7 @@ function AppearanceBuilder({ onRefresh }: Props) {
   return (
     <BuilderAccordion
       title="Appearance"
-      isComplete={isComplete}
+      hasChanges={hasChanges}
       isOpen={isOpen}
       onClick={onClick}
       onToggle={onToggle}

--- a/frontend/app/hooks/useBuilderSectionHandlers.ts
+++ b/frontend/app/hooks/useBuilderSectionHandlers.ts
@@ -7,7 +7,6 @@ export function useBuilderSectionHandlers(section: BuilderSection) {
 
   if (section === 'content') {
     return {
-      isComplete: uiState.contentComplete,
       isOpen: uiState.activeSection === 'content',
       onClick: (isOpen: boolean) => {
         uiActions.setActiveSection(
@@ -29,7 +28,6 @@ export function useBuilderSectionHandlers(section: BuilderSection) {
   }
 
   return {
-    isComplete: uiState.appearanceComplete,
     isOpen: uiState.activeSection === 'appearance',
     onClick: (isOpen: boolean) => {
       uiActions.setActiveSection(

--- a/frontend/app/stores/banner-store.ts
+++ b/frontend/app/stores/banner-store.ts
@@ -123,6 +123,7 @@ export const actions = {
 }
 
 export const {
+  useSectionHasChanges,
   subscribeProfilesToStorage,
   hydrateProfilesFromStorage,
   captureSnapshotsToStorage,

--- a/frontend/app/stores/paywall-store.ts
+++ b/frontend/app/stores/paywall-store.ts
@@ -124,6 +124,7 @@ export const actions = {
 }
 
 export const {
+  useSectionHasChanges,
   subscribeProfilesToStorage,
   hydrateProfilesFromStorage,
   captureSnapshotsToStorage,

--- a/frontend/app/stores/widget-store.ts
+++ b/frontend/app/stores/widget-store.ts
@@ -122,6 +122,7 @@ export const actions = {
 }
 
 export const {
+  useSectionHasChanges,
   subscribeProfilesToStorage,
   hydrateProfilesFromStorage,
   captureSnapshotsToStorage,

--- a/frontend/app/utils/utils.store.ts
+++ b/frontend/app/utils/utils.store.ts
@@ -1,5 +1,5 @@
 import { deepEqual } from 'fast-equals'
-import { snapshot, subscribe } from 'valtio'
+import { snapshot, subscribe, useSnapshot } from 'valtio'
 import {
   type BaseToolProfile,
   type ProfileId,
@@ -11,12 +11,15 @@ import {
 import type { BannerStore } from '~/stores/banner-store'
 import type { OfferwallStore } from '~/stores/offerwall-store'
 import type { PaywallStore } from '~/stores/paywall-store'
+import { toolState } from '~/stores/toolStore'
 import type { WidgetStore } from '~/stores/widget-store'
 import { diffProfile, type ChangedFields } from '~/utils/profile-diff'
-import { omit } from '~/utils/utils.storage'
+import { omit, splitProfileProperties } from '~/utils/utils.storage'
 
 type Store = BannerStore | WidgetStore | OfferwallStore | PaywallStore
 const STORAGE_PREFIX = 'wmt'
+
+type BuilderSection = 'content' | 'appearance'
 
 export function getStorageKeys(tool: Tool) {
   return {
@@ -96,6 +99,18 @@ export function createToolStoreUtils<T extends Tool>(
     })
   }
 
+  function useSectionHasChanges(section: BuilderSection): boolean {
+    const { activeTab } = useSnapshot(toolState)
+    const updates = useSnapshot(store.profilesUpdate)
+    const profile = useSnapshot(store.profiles[activeTab]) as ToolProfile<T>
+    if (!updates.has(activeTab)) return false
+    const baseline = snapshots.get(activeTab)
+    if (!baseline) return false
+    const cur = splitProfileProperties(profile)
+    const base = splitProfileProperties(baseline)
+    return !deepEqual(cur[section], base[section])
+  }
+
   function persistSnapshots() {
     localStorage.setItem(
       snapshotsStorageKey,
@@ -104,6 +119,8 @@ export function createToolStoreUtils<T extends Tool>(
   }
 
   return {
+    useSectionHasChanges,
+
     subscribeProfilesToStorage() {
       const unsubscribes = PROFILE_IDS.map(subscribeProfileToStorage)
       return () => unsubscribes.forEach((s) => s())


### PR DESCRIPTION
Closes #287

### Changes
Replaces the green check on collapsed builder sections (Banner/Widget/Paywall) with an edit icon that appears only when the section has unsaved changes from the saved baseline