### PR TITLE
refactor(frontend): use shared layout, utils on interactive tools

### DIFF
--- a/frontend/app/components/ToolLayoutWithPreview.tsx
+++ b/frontend/app/components/ToolLayoutWithPreview.tsx
@@ -208,7 +208,7 @@ function BuilderActions({ handleSave }: BuilderActionsProps) {
 
   const onClickScript = async () => {
     setIsLoadingScript(true)
-    await handleSave('script').finally(() => setIsLoading(false))
+    await handleSave('script').finally(() => setIsLoadingScript(false))
   }
 
   return (

--- a/frontend/app/components/ToolLayoutWithPreview.tsx
+++ b/frontend/app/components/ToolLayoutWithPreview.tsx
@@ -198,17 +198,17 @@ type BuilderActionsProps = {
 }
 
 function BuilderActions({ handleSave }: BuilderActionsProps) {
-  const [isLoading, setIsLoading] = useState(false)
-  const [isLoadingScript, setIsLoadingScript] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [isGenerating, setIsGenerating] = useState(false)
 
   const onClickSave = async () => {
-    setIsLoading(true)
-    await handleSave('save-success').finally(() => setIsLoading(false))
+    setIsSaving(true)
+    await handleSave('save-success').finally(() => setIsSaving(false))
   }
 
   const onClickScript = async () => {
-    setIsLoadingScript(true)
-    await handleSave('script').finally(() => setIsLoadingScript(false))
+    setIsGenerating(true)
+    await handleSave('script').finally(() => setIsGenerating(false))
   }
 
   return (
@@ -222,26 +222,26 @@ function BuilderActions({ handleSave }: BuilderActionsProps) {
       >
         <ToolsSecondaryButton
           className="xl:w-[150px] xl:rounded-lg w-full min-w-0 border-0 xl:border order-last xl:order-first"
-          disabled={isLoading}
+          disabled={isSaving}
           onClick={onClickSave}
         >
           <div className="flex items-center justify-center gap-2">
-            {isLoading && <SVGSpinner className="w-4 h-4" />}
-            <span>{isLoading ? 'Saving...' : 'Save edits only'}</span>
+            {isSaving && <SVGSpinner className="w-4 h-4" />}
+            <span>{isSaving ? 'Saving...' : 'Save edits only'}</span>
           </div>
         </ToolsSecondaryButton>
 
         <ToolsPrimaryButton
           icon="script"
-          iconPosition={isLoadingScript ? 'none' : 'left'}
+          iconPosition={isGenerating ? 'none' : 'left'}
           className="xl:w-[250px] xl:rounded-lg w-full min-w-0 order-first xl:order-last"
-          disabled={isLoadingScript}
+          disabled={isGenerating}
           onClick={onClickScript}
         >
           <div className="flex items-center justify-center gap-xs">
-            {isLoadingScript && <SVGSpinner className="w-4 h-4" />}
+            {isGenerating && <SVGSpinner className="w-4 h-4" />}
             <span>
-              {isLoadingScript ? 'Saving...' : 'Save and generate script'}
+              {isGenerating ? 'Saving...' : 'Save and generate script'}
             </span>
           </div>
         </ToolsPrimaryButton>

--- a/frontend/app/components/ToolLayoutWithPreview.tsx
+++ b/frontend/app/components/ToolLayoutWithPreview.tsx
@@ -40,9 +40,9 @@ type Props = React.PropsWithChildren<{
   walletAddressToolName: ComponentProps<typeof ToolsWalletAddress>['toolName']
   preview: ReactNode
   loaderData: {
-    grantResponse: string
-    isGrantAccepted: boolean
-    isGrantResponse: boolean
+    grantResponse?: string
+    isGrantAccepted?: boolean
+    isGrantResponse?: boolean
     OP_WALLET_ADDRESS: string
   }
 }>

--- a/frontend/app/components/ToolLayoutWithPreview.tsx
+++ b/frontend/app/components/ToolLayoutWithPreview.tsx
@@ -1,0 +1,251 @@
+import { useEffect, useState, type ComponentProps, type ReactNode } from 'react'
+import { useNavigate } from 'react-router'
+import {
+  HeadingCore,
+  MobileStepsIndicator,
+  ToolsPrimaryButton,
+  ToolsSecondaryButton,
+  ToolsWalletAddress,
+} from '@/components'
+import {
+  StepsIndicator,
+  type StepsIndicatorStep,
+} from '@/components/StepsIndicator'
+import { SVGSpinner } from '~/assets/svg'
+import { useBodyClass } from '~/hooks/useBodyClass'
+import { useGrantResponseHandler } from '~/hooks/useGrantResponseHandler'
+import { usePathTracker } from '~/hooks/usePathTracker'
+import { useSaveProfile } from '~/hooks/useSaveProfile'
+import { useScrollToWalletAddress } from '~/hooks/useScrollToWalletAddress'
+import { useToolWallet } from '~/hooks/useToolWallet'
+import { loadState, persistState } from '~/stores/toolStore'
+import type { createWalletStore } from '~/stores/wallet-store'
+import type { createToolStoreUtils } from '~/utils/utils.store'
+
+type Props = React.PropsWithChildren<{
+  title: string
+  description: ReactNode
+  additionalDescription?: ReactNode
+  walletStore: ReturnType<typeof createWalletStore>
+  toolStoreUtils: Pick<
+    ReturnType<typeof createToolStoreUtils>,
+    | 'subscribeProfilesToStorage'
+    | 'hydrateProfilesFromStorage'
+    | 'hydrateSnapshotsFromStorage'
+    | 'subscribeProfilesToUpdates'
+  >
+  steps: [StepsIndicatorStep] | [StepsIndicatorStep, StepsIndicatorStep]
+  // XXX: Fix me sometime - hacky for now
+  stepMiddle?: ReactNode
+  walletAddressToolName: ComponentProps<typeof ToolsWalletAddress>['toolName']
+  preview: ReactNode
+  loaderData: {
+    grantResponse: string
+    isGrantAccepted: boolean
+    isGrantResponse: boolean
+    OP_WALLET_ADDRESS: string
+  }
+}>
+
+export function ToolLayoutWithPreview({
+  title,
+  description,
+  additionalDescription,
+  walletStore,
+  toolStoreUtils,
+  walletAddressToolName,
+  steps,
+  stepMiddle: stepMiddle,
+  loaderData,
+  preview,
+  children,
+}: Props) {
+  const navigate = useNavigate()
+  const { walletAddressRef, scrollToWalletAddress } = useScrollToWalletAddress()
+
+  usePathTracker()
+  useBodyClass('has-fixed-action-bar')
+
+  const [walletSnap, walletActions] = useToolWallet({
+    wallet: walletStore.wallet,
+    actions: walletStore.actions,
+  })
+  const { save, saveLastAction } = useSaveProfile(walletStore.wallet)
+
+  useEffect(() => {
+    const unsubscribeUpdates = toolStoreUtils.subscribeProfilesToUpdates()
+    toolStoreUtils.hydrateProfilesFromStorage()
+    const unsubscribeStorage = toolStoreUtils.subscribeProfilesToStorage()
+    toolStoreUtils.hydrateSnapshotsFromStorage()
+
+    loadState(loaderData.OP_WALLET_ADDRESS)
+    persistState()
+    walletStore.load()
+    walletStore.persist()
+
+    return () => {
+      unsubscribeStorage()
+      unsubscribeUpdates()
+    }
+  }, [loaderData.OP_WALLET_ADDRESS])
+
+  useGrantResponseHandler(
+    loaderData.grantResponse,
+    loaderData.isGrantAccepted,
+    loaderData.isGrantResponse,
+    { onGrantSuccess: saveLastAction },
+  )
+
+  const handleSave = async (action: Parameters<typeof save>[0]) => {
+    if (!walletSnap.isWalletConnected) {
+      walletActions.setConnectWalletStep('error')
+      scrollToWalletAddress()
+      return
+    }
+    await save(action)
+  }
+
+  return (
+    <div className="bg-interface-bg-main w-full">
+      <div className="flex flex-col items-center pt-[60px] md:pt-3xl">
+        <div className="w-full max-w-[1280px]">
+          <div className=" px-md">
+            <HeadingCore title={title} onBackClick={() => navigate('/')}>
+              {description}
+            </HeadingCore>
+            {additionalDescription}
+          </div>
+
+          <div className="flex flex-col min-h-[756px] px-md xl:flex-row xl:items-start gap-lg">
+            <div
+              id="steps-indicator"
+              className="hidden xl:block w-[60px] flex-shrink-0 pt-md"
+            >
+              <StepsIndicator
+                steps={[
+                  {
+                    number: 1,
+                    label: 'Connect',
+                    status: walletSnap.walletConnectStep,
+                  },
+                  ...steps,
+                ]}
+              />
+            </div>
+
+            <div className="flex flex-col gap-2xl xl:gap-12 flex-1">
+              <div id="wallet-address" ref={walletAddressRef}>
+                <MobileStepsIndicator
+                  number={1}
+                  label="Connect"
+                  status={walletSnap.walletConnectStep}
+                />
+                <ToolsWalletAddress
+                  store={walletSnap}
+                  walletActions={walletActions}
+                  toolName={walletAddressToolName}
+                />
+              </div>
+
+              <div className="flex flex-col xl:flex-row gap-2xl">
+                <div className="flex flex-col gap-2xl xl:flex-1">
+                  {steps.length > 1 && stepMiddle && (
+                    <div
+                      id="configure-builder"
+                      className="w-full xl:max-w-[628px]"
+                    >
+                      <MobileStepsIndicator
+                        number={steps[0].number}
+                        label={steps[0].label}
+                        status={steps[0].status}
+                      />
+
+                      <div className="space-y-4">{stepMiddle}</div>
+                    </div>
+                  )}
+
+                  <div id="builder" className="w-full xl:max-w-[628px]">
+                    <MobileStepsIndicator
+                      number={steps.at(-1)!.number}
+                      label={steps.at(-1)!.label}
+                      status={steps.at(-1)!.status}
+                    />
+
+                    {children}
+
+                    <BuilderActions handleSave={handleSave} />
+                  </div>
+                </div>
+
+                <div
+                  id="preview"
+                  className="w-full mx-auto xl:mx-0 xl:sticky xl:top-md xl:self-start xl:flex-shrink-0 xl:w-[504px] h-fit"
+                >
+                  {preview}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+type SaveAction = 'save-success' | 'script'
+type BuilderActionsProps = {
+  handleSave: (action: SaveAction) => Promise<void>
+}
+
+function BuilderActions({ handleSave }: BuilderActionsProps) {
+  const [isLoading, setIsLoading] = useState(false)
+  const [isLoadingScript, setIsLoadingScript] = useState(false)
+
+  const onClickSave = async () => {
+    setIsLoading(true)
+    await handleSave('save-success').finally(() => setIsLoading(false))
+  }
+
+  const onClickScript = async () => {
+    setIsLoadingScript(true)
+    await handleSave('script').finally(() => setIsLoading(false))
+  }
+
+  return (
+    <div
+      id="builder-actions"
+      className="xl:flex xl:items-center xl:justify-end xl:gap-sm xl:mt-lg xl:static xl:bg-transparent xl:p-0 xl:border-0 xl:backdrop-blur-none xl:flex-row fixed bottom-0 left-0 right-0 flex flex-col gap-xs px-md sm:px-lg md:px-xl py-md bg-interface-bg-stickymenu/95 backdrop-blur-[20px] border-t border-field-border z-40"
+    >
+      <div
+        id="builder-actions-inner"
+        className="xl:contents flex flex-col gap-xs mx-auto w-full xl:w-auto xl:p-0 xl:mx-0 xl:flex-row xl:gap-sm"
+      >
+        <ToolsSecondaryButton
+          className="xl:w-[150px] xl:rounded-lg w-full min-w-0 border-0 xl:border order-last xl:order-first"
+          disabled={isLoading}
+          onClick={onClickSave}
+        >
+          <div className="flex items-center justify-center gap-2">
+            {isLoading && <SVGSpinner className="w-4 h-4" />}
+            <span>{isLoading ? 'Saving...' : 'Save edits only'}</span>
+          </div>
+        </ToolsSecondaryButton>
+
+        <ToolsPrimaryButton
+          icon="script"
+          iconPosition={isLoadingScript ? 'none' : 'left'}
+          className="xl:w-[250px] xl:rounded-lg w-full min-w-0 order-first xl:order-last"
+          disabled={isLoadingScript}
+          onClick={onClickScript}
+        >
+          <div className="flex items-center justify-center gap-xs">
+            {isLoadingScript && <SVGSpinner className="w-4 h-4" />}
+            <span>
+              {isLoadingScript ? 'Saving...' : 'Save and generate script'}
+            </span>
+          </div>
+        </ToolsPrimaryButton>
+      </div>
+    </div>
+  )
+}

--- a/frontend/app/components/ToolLayoutWithPreview.tsx
+++ b/frontend/app/components/ToolLayoutWithPreview.tsx
@@ -55,7 +55,7 @@ export function ToolLayoutWithPreview({
   toolStoreUtils,
   walletAddressToolName,
   steps,
-  stepMiddle: stepMiddle,
+  stepMiddle,
   loaderData,
   preview,
   children,

--- a/frontend/app/components/redesign/components/StepsIndicator.tsx
+++ b/frontend/app/components/redesign/components/StepsIndicator.tsx
@@ -11,7 +11,7 @@ interface StepProps {
   textPosition?: TextPosition
 }
 
-interface StepsIndicatorStep {
+export interface StepsIndicatorStep {
   number: number
   label: string
   status: StepStatus

--- a/frontend/app/routes/banner.tsx
+++ b/frontend/app/routes/banner.tsx
@@ -1,21 +1,14 @@
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import {
   useLoaderData,
-  useNavigate,
   data,
   type LoaderFunctionArgs,
   type MetaFunction,
 } from 'react-router'
 import { useSnapshot } from 'valtio'
-import { SVGSpinner } from '@/assets'
 import {
-  HeadingCore,
-  ToolsWalletAddress,
   BuilderBackground,
   ToolsSecondaryButton,
-  ToolsPrimaryButton,
-  StepsIndicator,
-  MobileStepsIndicator,
   BuilderProfileTabs,
 } from '@/components'
 import { SLIDE_ANIMATION } from '@shared/types'
@@ -24,12 +17,7 @@ import {
   BannerPreview,
   type BannerHandle,
 } from '~/components/banner/BannerPreview'
-import { useBodyClass } from '~/hooks/useBodyClass'
-import { useGrantResponseHandler } from '~/hooks/useGrantResponseHandler'
-import { usePathTracker } from '~/hooks/usePathTracker'
-import { useSaveProfile } from '~/hooks/useSaveProfile'
-import { useScrollToWalletAddress } from '~/hooks/useScrollToWalletAddress'
-import { useToolWallet } from '~/hooks/useToolWallet'
+import { ToolLayoutWithPreview } from '~/components/ToolLayoutWithPreview'
 import {
   actions,
   banner,
@@ -43,12 +31,7 @@ import {
   subscribeProfilesToUpdates,
   useBannerProfile,
 } from '~/stores/banner-store'
-import {
-  toolState,
-  toolActions,
-  persistState,
-  loadState,
-} from '~/stores/toolStore'
+import { toolState, toolActions } from '~/stores/toolStore'
 import { useUIActions } from '~/stores/uiStore'
 import { commitSession, getSession } from '~/utils/session.server.js'
 
@@ -89,218 +72,98 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
   )
 }
 
-export default function Banner() {
+export default function Paywall() {
   const snap = useSnapshot(toolState)
-  const [walletSnap, walletActions] = useToolWallet({
-    wallet: bannerWallet,
-    actions: bannerWalletActions,
-  })
   const bannerSnap = useSnapshot(banner)
-  const [profile] = useBannerProfile()
-  const navigate = useNavigate()
   const uiActions = useUIActions()
-  const { save, saveLastAction } = useSaveProfile(bannerWallet)
-  const { walletAddressRef, scrollToWalletAddress } = useScrollToWalletAddress()
-  const [isLoading, setIsLoading] = useState(false)
-  const [isLoadingScript, setIsLoadingScript] = useState(false)
-  const bannerRef = useRef<BannerHandle>(null)
+
   const { grantResponse, isGrantAccepted, isGrantResponse, OP_WALLET_ADDRESS } =
     useLoaderData<typeof loader>()
-  usePathTracker()
-  useBodyClass('has-fixed-action-bar')
 
   useEffect(() => {
     uiActions.setActiveSection('content')
-    const unsubscribeUpdates = subscribeProfilesToUpdates()
-    hydrateProfilesFromStorage()
-    const unsubscribeStorage = subscribeProfilesToStorage()
-    hydrateSnapshotsFromStorage()
-
-    loadState(OP_WALLET_ADDRESS)
-    persistState()
-    loadBannerWallet()
-    persistBannerWallet()
-
-    return () => {
-      unsubscribeStorage()
-      unsubscribeUpdates()
-    }
   }, [OP_WALLET_ADDRESS])
 
-  useGrantResponseHandler(grantResponse, isGrantAccepted, isGrantResponse, {
-    onGrantSuccess: saveLastAction,
-  })
+  return (
+    <ToolLayoutWithPreview
+      title="Banner"
+      description={
+        <>
+          The drawer banner informs visitors who don&apos;t have the Web
+          Monetization extension active, with a call-to-action linking to the
+          extension or providing details about the options available.
+          <br />
+          It also adds your wallet address for your site to be monetized.
+        </>
+      }
+      walletStore={{
+        wallet: bannerWallet,
+        actions: bannerWalletActions,
+        load: loadBannerWallet,
+        persist: persistBannerWallet,
+      }}
+      toolStoreUtils={{
+        subscribeProfilesToStorage,
+        hydrateProfilesFromStorage,
+        hydrateSnapshotsFromStorage,
+        subscribeProfilesToUpdates,
+      }}
+      walletAddressToolName="drawer banner"
+      steps={[{ number: 2, label: 'Build', status: snap.buildStep }]}
+      preview={<Preview cdnUrl={snap.cdnUrl} />}
+      loaderData={{
+        grantResponse,
+        isGrantAccepted,
+        isGrantResponse,
+        OP_WALLET_ADDRESS,
+      }}
+    >
+      <BuilderProfileTabs
+        idPrefix="profile"
+        options={bannerSnap.profileTabs}
+        selectedId={snap.activeTab}
+        onChange={(profileId) => toolActions.setActiveTab(profileId)}
+        onRename={(name) => actions.setProfileName(name)}
+      >
+        <BannerBuilder
+          onRefresh={(section) => actions.resetProfileSection(section)}
+        />
+      </BuilderProfileTabs>
+    </ToolLayoutWithPreview>
+  )
+}
 
-  const handleSave = async (action: 'save-success' | 'script') => {
-    if (!walletSnap.isWalletConnected) {
-      walletActions.setConnectWalletStep('error')
-      scrollToWalletAddress()
-      return
-    }
+function Preview({ cdnUrl }: { cdnUrl: string }) {
+  const [profile] = useBannerProfile()
 
-    const isScript = action === 'script'
-    const setLoading = isScript ? setIsLoadingScript : setIsLoading
-
-    setLoading(true)
-    try {
-      await save(action)
-    } finally {
-      setLoading(false)
-    }
-  }
-
+  const isAnimationDisabled = profile.animation.type === SLIDE_ANIMATION.None
+  const bannerRef = useRef<BannerHandle>(null)
   const handlePreviewClick = () => {
     if (bannerRef.current) {
       bannerRef.current.triggerPreview()
     }
   }
 
-  const isAnimationDisabled = profile.animation.type === SLIDE_ANIMATION.None
   return (
-    <div className="bg-interface-bg-main w-full">
-      <div className="flex flex-col items-center pt-[60px] md:pt-3xl">
-        <div className="w-full max-w-[1280px] px-md">
-          <HeadingCore title="Banner" onBackClick={() => navigate('/')}>
-            The drawer banner informs visitors who don&apos;t have the Web
-            Monetization extension active, with a call-to-action linking to the
-            extension or providing details about the options available.
-            <br />
-            It also adds your wallet address for your site to be monetized.
-          </HeadingCore>
-          <div className="flex flex-col min-h-[756px]">
-            <div className="flex flex-col xl:flex-row xl:items-start gap-lg">
-              <div
-                id="steps-indicator"
-                className="hidden xl:block w-[60px] flex-shrink-0 pt-md"
-              >
-                <StepsIndicator
-                  steps={[
-                    {
-                      number: 1,
-                      label: 'Connect',
-                      status: walletSnap.walletConnectStep,
-                    },
-                    {
-                      number: 2,
-                      label: 'Build',
-                      status: snap.buildStep,
-                    },
-                  ]}
-                />
-              </div>
-
-              <div className="flex flex-col gap-2xl xl:gap-12 flex-1">
-                <div id="wallet-address" ref={walletAddressRef}>
-                  <MobileStepsIndicator
-                    number={1}
-                    label="Connect"
-                    status={walletSnap.walletConnectStep}
-                  />
-                  <ToolsWalletAddress
-                    store={walletSnap}
-                    walletActions={walletActions}
-                    toolName="drawer banner"
-                  />
-                </div>
-
-                <div className="flex flex-col xl:flex-row gap-2xl">
-                  <div
-                    id="builder"
-                    className="w-full xl:max-w-[628px] xl:flex-1"
-                  >
-                    <MobileStepsIndicator
-                      number={2}
-                      label="Build"
-                      status={snap.buildStep}
-                    />
-
-                    <BuilderProfileTabs
-                      idPrefix="profile"
-                      options={bannerSnap.profileTabs}
-                      selectedId={snap.activeTab}
-                      onChange={(profileId) =>
-                        toolActions.setActiveTab(profileId)
-                      }
-                      onRename={(name) => actions.setProfileName(name)}
-                    >
-                      <BannerBuilder
-                        onRefresh={(section) =>
-                          actions.resetProfileSection(section)
-                        }
-                      />
-                    </BuilderProfileTabs>
-
-                    <div
-                      id="builder-actions"
-                      className="xl:flex xl:items-center xl:justify-end xl:gap-sm xl:mt-lg xl:static xl:bg-transparent xl:p-0 xl:border-0 xl:backdrop-blur-none xl:flex-row
-                                fixed bottom-0 left-0 right-0 flex flex-col gap-xs px-md sm:px-lg md:px-xl py-md bg-interface-bg-stickymenu/95 backdrop-blur-[20px] border-t border-field-border z-40"
-                    >
-                      <div
-                        id="builder-actions-inner"
-                        className="xl:contents flex flex-col gap-xs mx-auto w-full xl:w-auto xl:p-0 xl:mx-0 xl:flex-row xl:gap-sm"
-                      >
-                        <ToolsSecondaryButton
-                          className="xl:w-[150px] xl:rounded-lg
-                                    w-full min-w-0 border-0 xl:border order-last xl:order-first"
-                          disabled={isLoading}
-                          onClick={() => handleSave('save-success')}
-                        >
-                          <div className="flex items-center justify-center gap-2">
-                            {isLoading && <SVGSpinner className="w-4 h-4" />}
-                            <span>
-                              {isLoading ? 'Saving...' : 'Save edits only'}
-                            </span>
-                          </div>
-                        </ToolsSecondaryButton>
-                        <ToolsPrimaryButton
-                          icon="script"
-                          iconPosition={isLoadingScript ? 'none' : 'left'}
-                          className="xl:w-[250px] xl:rounded-lg
-                                    w-full min-w-0 order-first xl:order-last"
-                          disabled={isLoadingScript}
-                          onClick={() => handleSave('script')}
-                        >
-                          <div className="flex items-center justify-center gap-xs">
-                            {isLoadingScript && (
-                              <SVGSpinner className="w-4 h-4" />
-                            )}
-                            <span>
-                              {isLoadingScript
-                                ? 'Saving...'
-                                : 'Save and generate script'}
-                            </span>
-                          </div>
-                        </ToolsPrimaryButton>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div
-                    id="preview"
-                    className="w-full mx-auto xl:mx-0 xl:sticky xl:top-md xl:self-start xl:flex-shrink-0 xl:w-[504px] h-fit"
-                  >
-                    <BuilderBackground
-                      actions={
-                        !isAnimationDisabled && (
-                          <ToolsSecondaryButton
-                            icon="play"
-                            className="w-[130px]"
-                            onClick={handlePreviewClick}
-                          >
-                            Preview
-                          </ToolsSecondaryButton>
-                        )
-                      }
-                    >
-                      <BannerPreview ref={bannerRef} cdnUrl={snap.cdnUrl} />
-                    </BuilderBackground>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+    <div
+      id="preview"
+      className="w-full mx-auto xl:mx-0 xl:sticky xl:top-md xl:self-start xl:flex-shrink-0 xl:w-[504px] h-fit"
+    >
+      <BuilderBackground
+        actions={
+          !isAnimationDisabled && (
+            <ToolsSecondaryButton
+              icon="play"
+              className="w-[130px]"
+              onClick={handlePreviewClick}
+            >
+              Preview
+            </ToolsSecondaryButton>
+          )
+        }
+      >
+        <BannerPreview ref={bannerRef} cdnUrl={cdnUrl} />
+      </BuilderBackground>
     </div>
   )
 }

--- a/frontend/app/routes/banner.tsx
+++ b/frontend/app/routes/banner.tsx
@@ -72,7 +72,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
   )
 }
 
-export default function Paywall() {
+export default function Banner() {
   const snap = useSnapshot(toolState)
   const bannerSnap = useSnapshot(banner)
   const uiActions = useUIActions()

--- a/frontend/app/routes/banner.tsx
+++ b/frontend/app/routes/banner.tsx
@@ -145,25 +145,20 @@ function Preview({ cdnUrl }: { cdnUrl: string }) {
   }
 
   return (
-    <div
-      id="preview"
-      className="w-full mx-auto xl:mx-0 xl:sticky xl:top-md xl:self-start xl:flex-shrink-0 xl:w-[504px] h-fit"
+    <BuilderBackground
+      actions={
+        !isAnimationDisabled && (
+          <ToolsSecondaryButton
+            icon="play"
+            className="w-[130px]"
+            onClick={handlePreviewClick}
+          >
+            Preview
+          </ToolsSecondaryButton>
+        )
+      }
     >
-      <BuilderBackground
-        actions={
-          !isAnimationDisabled && (
-            <ToolsSecondaryButton
-              icon="play"
-              className="w-[130px]"
-              onClick={handlePreviewClick}
-            >
-              Preview
-            </ToolsSecondaryButton>
-          )
-        }
-      >
-        <BannerPreview ref={bannerRef} cdnUrl={cdnUrl} />
-      </BuilderBackground>
-    </div>
+      <BannerPreview ref={bannerRef} cdnUrl={cdnUrl} />
+    </BuilderBackground>
   )
 }

--- a/frontend/app/routes/offerwall.tsx
+++ b/frontend/app/routes/offerwall.tsx
@@ -121,13 +121,8 @@ export default function Offerwall() {
 
 function Preview() {
   return (
-    <div
-      id="preview"
-      className="w-full mx-auto xl:mx-0 xl:sticky xl:top-md xl:self-start xl:flex-shrink-0 xl:w-[504px] h-fit"
-    >
-      <BuilderBackground>
-        <OfferwallPreview />
-      </BuilderBackground>
-    </div>
+    <BuilderBackground>
+      <OfferwallPreview />
+    </BuilderBackground>
   )
 }

--- a/frontend/app/routes/offerwall.tsx
+++ b/frontend/app/routes/offerwall.tsx
@@ -1,33 +1,15 @@
-import { useEffect, useState } from 'react'
 import {
   data,
   useLoaderData,
-  useNavigate,
   type MetaFunction,
   type LoaderFunctionArgs,
 } from 'react-router'
 import { useSnapshot } from 'valtio'
-import { SVGSpinner } from '@/assets'
-import {
-  BuilderBackground,
-  BuilderProfileTabs,
-  Divider,
-  HeadingCore,
-  MobileStepsIndicator,
-  StepsIndicator,
-  ToolsPrimaryButton,
-  ToolsSecondaryButton,
-  ToolsWalletAddress,
-} from '@/components'
+import { BuilderBackground, BuilderProfileTabs, Divider } from '@/components'
 import HowItWorks from '~/components/offerwall/HowItWorks'
 import { OfferwallBuilder } from '~/components/offerwall/OfferwallBuilder'
 import OfferwallPreview from '~/components/offerwall/OfferwallPreview'
-import { useBodyClass } from '~/hooks/useBodyClass'
-import { useGrantResponseHandler } from '~/hooks/useGrantResponseHandler'
-import { usePathTracker } from '~/hooks/usePathTracker'
-import { useSaveProfile } from '~/hooks/useSaveProfile'
-import { useScrollToWalletAddress } from '~/hooks/useScrollToWalletAddress'
-import { useToolWallet } from '~/hooks/useToolWallet'
+import { ToolLayoutWithPreview } from '~/components/ToolLayoutWithPreview'
 import {
   actions,
   hydrateProfilesFromStorage,
@@ -40,12 +22,7 @@ import {
   subscribeProfilesToStorage,
   subscribeProfilesToUpdates,
 } from '~/stores/offerwall-store'
-import {
-  loadState,
-  persistState,
-  toolActions,
-  toolState,
-} from '~/stores/toolStore'
+import { toolActions, toolState } from '~/stores/toolStore'
 import { commitSession, getSession } from '~/utils/session.server'
 
 export const meta: MetaFunction = () => {
@@ -87,195 +64,70 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
 
 export default function Offerwall() {
   const snap = useSnapshot(toolState)
-  const [walletSnap, walletActions] = useToolWallet({
-    wallet: offerwallWallet,
-    actions: offerwallWalletActions,
-  })
   const offerwallSnap = useSnapshot(offerwall)
-  const navigate = useNavigate()
-  const { save, saveLastAction } = useSaveProfile(offerwallWallet)
-  const { walletAddressRef, scrollToWalletAddress } = useScrollToWalletAddress()
-  const [isLoading, setIsLoading] = useState(false)
-  const [isLoadingScript, setIsLoadingScript] = useState(false)
+
   const { grantResponse, isGrantAccepted, isGrantResponse, OP_WALLET_ADDRESS } =
     useLoaderData<typeof loader>()
-  usePathTracker()
-  useBodyClass('has-fixed-action-bar')
-
-  useEffect(() => {
-    const unsubscribeUpdates = subscribeProfilesToUpdates()
-    hydrateProfilesFromStorage()
-    const unsubscribeStorage = subscribeProfilesToStorage()
-    hydrateSnapshotsFromStorage()
-
-    loadState(OP_WALLET_ADDRESS)
-    persistState()
-    loadOfferwallWallet()
-    persistOfferwallWallet()
-
-    return () => {
-      unsubscribeStorage()
-      unsubscribeUpdates()
-    }
-  }, [OP_WALLET_ADDRESS])
-
-  useGrantResponseHandler(grantResponse, isGrantAccepted, isGrantResponse, {
-    onGrantSuccess: saveLastAction,
-  })
-
-  const handleSave = async (action: 'save-success' | 'script') => {
-    if (!walletSnap.isWalletConnected) {
-      walletActions.setConnectWalletStep('error')
-      scrollToWalletAddress()
-      return
-    }
-
-    const isScript = action === 'script'
-    const setLoading = isScript ? setIsLoadingScript : setIsLoading
-
-    setLoading(true)
-    try {
-      await save(action)
-    } finally {
-      setLoading(false)
-    }
-  }
 
   return (
-    <div className="bg-interface-bg-main w-full">
-      <div className="flex flex-col items-center pt-[60px] md:pt-3xl">
-        <div className="w-full max-w-[1280px]">
-          <HeadingCore
-            title="Offerwall experience"
-            onBackClick={() => navigate('/')}
-          >
-            The Offerwall experience helps visitors who don’t yet have Web
-            Monetization enabled discover it and support your content.
-          </HeadingCore>
+    <ToolLayoutWithPreview
+      title="Offerwall experience"
+      description={
+        <>
+          The Offerwall experience helps visitors who don’t yet have Web
+          Monetization enabled discover it and support your content.
+        </>
+      }
+      additionalDescription={
+        <>
           <HowItWorks />
-
           <Divider className="!my-3xl" />
+        </>
+      }
+      walletStore={{
+        wallet: offerwallWallet,
+        actions: offerwallWalletActions,
+        load: loadOfferwallWallet,
+        persist: persistOfferwallWallet,
+      }}
+      toolStoreUtils={{
+        subscribeProfilesToStorage,
+        hydrateProfilesFromStorage,
+        hydrateSnapshotsFromStorage,
+        subscribeProfilesToUpdates,
+      }}
+      steps={[{ number: 2, label: 'Build', status: snap.buildStep }]}
+      walletAddressToolName="offerwall experience"
+      preview={<Preview />}
+      loaderData={{
+        grantResponse,
+        isGrantAccepted,
+        isGrantResponse,
+        OP_WALLET_ADDRESS,
+      }}
+    >
+      <BuilderProfileTabs
+        idPrefix="profile"
+        options={offerwallSnap.profileTabs}
+        selectedId={snap.activeTab}
+        onChange={(profileId) => toolActions.setActiveTab(profileId)}
+        onRename={(name) => actions.setProfileName(name)}
+      >
+        <OfferwallBuilder onRefresh={() => actions.resetProfileSection()} />
+      </BuilderProfileTabs>
+    </ToolLayoutWithPreview>
+  )
+}
 
-          <div className="flex flex-col min-h-[756px] px-md xl:flex-row xl:items-start gap-lg">
-            <>
-              <div
-                id="steps-indicator"
-                className="hidden xl:block w-[60px] flex-shrink-0 pt-md"
-              >
-                <StepsIndicator
-                  steps={[
-                    {
-                      number: 1,
-                      label: 'Connect',
-                      status: walletSnap.walletConnectStep,
-                    },
-                    {
-                      number: 2,
-                      label: 'Build',
-                      status: snap.buildStep,
-                    },
-                  ]}
-                />
-              </div>
-
-              <div className="flex flex-col gap-2xl xl:gap-12 flex-1">
-                <div id="wallet-address" ref={walletAddressRef}>
-                  <MobileStepsIndicator
-                    number={1}
-                    label="Connect"
-                    status={walletSnap.walletConnectStep}
-                  />
-                  <ToolsWalletAddress
-                    store={walletSnap}
-                    walletActions={walletActions}
-                    toolName="offerwall experience"
-                  />
-                </div>
-
-                <div className="flex flex-col xl:flex-row gap-2xl">
-                  <div
-                    id="builder"
-                    className="w-full xl:max-w-[628px] xl:flex-1"
-                  >
-                    <MobileStepsIndicator
-                      number={2}
-                      label="Build"
-                      status={snap.buildStep}
-                    />
-
-                    <BuilderProfileTabs
-                      idPrefix="profile"
-                      options={offerwallSnap.profileTabs}
-                      selectedId={snap.activeTab}
-                      onChange={(profileId) =>
-                        toolActions.setActiveTab(profileId)
-                      }
-                      onRename={(name) => actions.setProfileName(name)}
-                    >
-                      <OfferwallBuilder
-                        onRefresh={() => actions.resetProfileSection()}
-                      />
-                    </BuilderProfileTabs>
-
-                    <div
-                      id="builder-actions"
-                      className="xl:flex xl:items-center xl:justify-end xl:gap-sm xl:mt-lg xl:static xl:bg-transparent xl:p-0 xl:border-0 xl:backdrop-blur-none xl:flex-row
-                                           fixed bottom-0 left-0 right-0 flex flex-col gap-xs px-md sm:px-lg md:px-xl py-md bg-interface-bg-stickymenu/95 backdrop-blur-[20px] border-t border-field-border z-40"
-                    >
-                      <div
-                        id="builder-actions-inner"
-                        className="xl:contents flex flex-col gap-xs mx-auto w-full xl:w-auto xl:p-0 xl:mx-0 xl:flex-row xl:gap-sm"
-                      >
-                        <ToolsSecondaryButton
-                          className="xl:w-[150px] xl:rounded-lg
-                                               w-full min-w-0 border-0 xl:border order-last xl:order-first"
-                          disabled={isLoading}
-                          onClick={() => handleSave('save-success')}
-                        >
-                          <div className="flex items-center justify-center gap-2">
-                            {isLoading && <SVGSpinner className="w-4 h-4" />}
-                            <span>
-                              {isLoading ? 'Saving...' : 'Save edits only'}
-                            </span>
-                          </div>
-                        </ToolsSecondaryButton>
-                        <ToolsPrimaryButton
-                          icon="script"
-                          iconPosition={isLoadingScript ? 'none' : 'left'}
-                          className="xl:w-[250px] xl:rounded-lg
-                                               w-full min-w-0 order-first xl:order-last"
-                          disabled={isLoadingScript}
-                          onClick={() => handleSave('script')}
-                        >
-                          <div className="flex items-center justify-center gap-xs">
-                            {isLoadingScript && (
-                              <SVGSpinner className="w-4 h-4" />
-                            )}
-                            <span>
-                              {isLoadingScript
-                                ? 'Saving...'
-                                : 'Save and generate script'}
-                            </span>
-                          </div>
-                        </ToolsPrimaryButton>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div
-                    id="preview"
-                    className="w-full mx-auto xl:mx-0 xl:sticky xl:top-md xl:self-start xl:flex-shrink-0 xl:w-[504px] h-fit"
-                  >
-                    <BuilderBackground>
-                      <OfferwallPreview />
-                    </BuilderBackground>
-                  </div>
-                </div>
-              </div>
-            </>
-          </div>
-        </div>
-      </div>
+function Preview() {
+  return (
+    <div
+      id="preview"
+      className="w-full mx-auto xl:mx-0 xl:sticky xl:top-md xl:self-start xl:flex-shrink-0 xl:w-[504px] h-fit"
+    >
+      <BuilderBackground>
+        <OfferwallPreview />
+      </BuilderBackground>
     </div>
   )
 }

--- a/frontend/app/routes/paywall.tsx
+++ b/frontend/app/routes/paywall.tsx
@@ -105,16 +105,8 @@ export default function Paywall() {
       }}
       walletAddressToolName="pay per article"
       steps={[
-        {
-          number: 2,
-          label: 'Configure',
-          status: snap.configureStep,
-        },
-        {
-          number: 3,
-          label: 'Build',
-          status: snap.buildStep,
-        },
+        { number: 2, label: 'Configure', status: snap.configureStep },
+        { number: 3, label: 'Build', status: snap.buildStep },
       ]}
       preview={<Preview />}
       loaderData={{

--- a/frontend/app/routes/paywall.tsx
+++ b/frontend/app/routes/paywall.tsx
@@ -85,9 +85,9 @@ export default function Paywall() {
       title={t('title')}
       description={
         <>
-          {t('description_0')}
-          <br />
           {t('description_1')}
+          <br />
+          {t('description_2')}
         </>
       }
       additionalDescription={<Divider className="!my-3xl" />}

--- a/frontend/app/routes/paywall.tsx
+++ b/frontend/app/routes/paywall.tsx
@@ -1,31 +1,17 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import {
   data,
   useLoaderData,
-  useNavigate,
   type MetaFunction,
   type LoaderFunctionArgs,
 } from 'react-router'
 import { useSnapshot } from 'valtio'
-import { SVGSpinner } from '@/assets'
-import {
-  Divider,
-  HeadingCore,
-  MobileStepsIndicator,
-  StepsIndicator,
-  ToolsPrimaryButton,
-  ToolsSecondaryButton,
-  ToolsWalletAddress,
-} from '@/components'
 import { PaywallBuilder } from '~/components/paywall/PaywallBuilder'
 import { PaywallPlacementBuilder } from '~/components/paywall/PaywallPlacementBuilder'
 import { PaywallPreview } from '~/components/paywall/PaywallPreview'
 import { PaywallPriceBuilder } from '~/components/paywall/PaywallPriceBuilder'
-import { useBodyClass } from '~/hooks/useBodyClass'
-import { useGrantResponseHandler } from '~/hooks/useGrantResponseHandler'
-import { usePathTracker } from '~/hooks/usePathTracker'
-import { useSaveProfile } from '~/hooks/useSaveProfile'
-import { useScrollToWalletAddress } from '~/hooks/useScrollToWalletAddress'
+import { Divider } from '~/components/redesign/components'
+import { ToolLayoutWithPreview } from '~/components/ToolLayoutWithPreview'
 import { useToolWallet } from '~/hooks/useToolWallet'
 import {
   actions,
@@ -39,13 +25,7 @@ import {
   subscribeProfilesToStorage,
   subscribeProfilesToUpdates,
 } from '~/stores/paywall-store'
-import {
-  loadState,
-  persistState,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  toolActions,
-  toolState,
-} from '~/stores/toolStore'
+import { toolState } from '~/stores/toolStore'
 import { commitSession, getSession } from '~/utils/session.server'
 
 export const meta: MetaFunction = () => {
@@ -86,217 +66,86 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
 
 export default function Paywall() {
   const snap = useSnapshot(toolState)
-  const [walletSnap, walletActions] = useToolWallet({
+  const [walletSnap] = useToolWallet({
     wallet: paywallWallet,
     actions: paywallWalletActions,
   })
-  const navigate = useNavigate()
-  const { save, saveLastAction } = useSaveProfile(paywallWallet)
-  const { walletAddressRef, scrollToWalletAddress } = useScrollToWalletAddress()
-  const [isLoading, setIsLoading] = useState(false)
-  const [isLoadingScript, setIsLoadingScript] = useState(false)
   const { grantResponse, isGrantAccepted, isGrantResponse, OP_WALLET_ADDRESS } =
     useLoaderData<typeof loader>()
-  usePathTracker()
-  useBodyClass('has-fixed-action-bar')
-
-  useEffect(() => {
-    const unsubscribeUpdates = subscribeProfilesToUpdates()
-    hydrateProfilesFromStorage()
-    const unsubscribeStorage = subscribeProfilesToStorage()
-    hydrateSnapshotsFromStorage()
-
-    loadState(OP_WALLET_ADDRESS)
-    persistState()
-    loadPaywallWallet()
-    persistPaywallWallet()
-
-    return () => {
-      unsubscribeStorage()
-      unsubscribeUpdates()
-    }
-  }, [OP_WALLET_ADDRESS])
 
   useEffect(() => {
     paywall.profile.price.currency =
       walletSnap.walletAddressInfo?.assetCode || 'USD'
   }, [walletSnap.walletAddressInfo])
 
-  useGrantResponseHandler(grantResponse, isGrantAccepted, isGrantResponse, {
-    onGrantSuccess: saveLastAction,
-  })
-
-  const handleSave = async (action: 'save-success' | 'script') => {
-    if (!walletSnap.isWalletConnected) {
-      walletActions.setConnectWalletStep('error')
-      scrollToWalletAddress()
-      return
-    }
-
-    const isScript = action === 'script'
-    const setLoading = isScript ? setIsLoadingScript : setIsLoading
-
-    setLoading(true)
-    try {
-      await save(action)
-    } finally {
-      setLoading(false)
-    }
-  }
-
   return (
-    <div className="bg-interface-bg-main w-full">
-      <div className="flex flex-col items-center pt-[60px] md:pt-3xl">
-        <div className="w-full max-w-[1280px]">
-          <HeadingCore
-            title="Pay Per Article"
-            onBackClick={() => navigate('/')}
-          >
-            Pay Per Article lets visitors unlock gated content with a one-time
-            payment.
-            <br />
-            It provides a clean, customizable interface to configure pricing,
-            and choose how locked content is revealed.
-          </HeadingCore>
-
-          <Divider className="!my-3xl" />
-
-          <div className="flex flex-col min-h-[756px] px-md xl:flex-row xl:items-start gap-lg">
-            <>
-              <div
-                id="steps-indicator"
-                className="hidden xl:block w-[60px] flex-shrink-0 pt-md"
-              >
-                <StepsIndicator
-                  steps={[
-                    {
-                      number: 1,
-                      label: 'Connect',
-                      status: walletSnap.walletConnectStep,
-                    },
-                    {
-                      number: 2,
-                      label: 'Configure',
-                      status: snap.configureStep,
-                    },
-                    {
-                      number: 3,
-                      label: 'Build',
-                      status: snap.buildStep,
-                    },
-                  ]}
-                />
-              </div>
-            </>
-
-            <div className="flex flex-col gap-2xl xl:gap-12 flex-1">
-              <>
-                <div id="wallet-address" ref={walletAddressRef}>
-                  <MobileStepsIndicator
-                    number={1}
-                    label="Connect"
-                    status={walletSnap.walletConnectStep}
-                  />
-                  <ToolsWalletAddress
-                    store={walletSnap}
-                    walletActions={walletActions}
-                    toolName="pay per article"
-                  />
-                </div>
-              </>
-
-              <div className="flex flex-col xl:flex-row gap-2xl">
-                <div className="flex flex-col gap-2xl xl:flex-1">
-                  <div
-                    id="configure-builder"
-                    className="w-full xl:max-w-[628px]"
-                  >
-                    <MobileStepsIndicator
-                      number={2}
-                      label="Configure"
-                      status={snap.configureStep}
-                    />
-
-                    <div className="space-y-4">
-                      <PaywallPriceBuilder />
-                      <PaywallPlacementBuilder />
-                    </div>
-                  </div>
-
-                  <div id="builder" className="w-full xl:max-w-[628px]">
-                    <MobileStepsIndicator
-                      number={3}
-                      label="Build"
-                      status={snap.buildStep}
-                    />
-
-                    <div className="bg-interface-bg-container rounded-sm p-md flex-col gap-md w-full -mt-2 flex">
-                      <PaywallBuilder
-                        onRefresh={(section) =>
-                          actions.resetProfileSection(section)
-                        }
-                      />
-                    </div>
-
-                    <div
-                      id="builder-actions"
-                      className="xl:flex xl:items-center xl:justify-end xl:gap-sm xl:mt-lg xl:static xl:bg-transparent xl:p-0 xl:border-0 xl:backdrop-blur-none xl:flex-row
-                                           fixed bottom-0 left-0 right-0 flex flex-col gap-xs px-md sm:px-lg md:px-xl py-md bg-interface-bg-stickymenu/95 backdrop-blur-[20px] border-t border-field-border z-40"
-                    >
-                      <div
-                        id="builder-actions-inner"
-                        className="xl:contents flex flex-col gap-xs mx-auto w-full xl:w-auto xl:p-0 xl:mx-0 xl:flex-row xl:gap-sm"
-                      >
-                        <ToolsSecondaryButton
-                          className="xl:w-[150px] xl:rounded-lg
-                                               w-full min-w-0 border-0 xl:border order-last xl:order-first"
-                          disabled={isLoading}
-                          onClick={() => handleSave('save-success')}
-                        >
-                          <div className="flex items-center justify-center gap-2">
-                            {isLoading && <SVGSpinner className="w-4 h-4" />}
-                            <span>
-                              {isLoading ? 'Saving...' : 'Save edits only'}
-                            </span>
-                          </div>
-                        </ToolsSecondaryButton>
-                        <ToolsPrimaryButton
-                          icon="script"
-                          iconPosition={isLoadingScript ? 'none' : 'left'}
-                          className="xl:w-[250px] xl:rounded-lg
-                                               w-full min-w-0 order-first xl:order-last"
-                          disabled={isLoadingScript}
-                          onClick={() => handleSave('script')}
-                        >
-                          <div className="flex items-center justify-center gap-xs">
-                            {isLoadingScript && (
-                              <SVGSpinner className="w-4 h-4" />
-                            )}
-                            <span>
-                              {isLoadingScript
-                                ? 'Saving...'
-                                : 'Save and generate script'}
-                            </span>
-                          </div>
-                        </ToolsPrimaryButton>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                <>
-                  <div
-                    id="preview"
-                    className="w-full mx-auto xl:mx-0 xl:sticky xl:top-md xl:self-start xl:flex-shrink-0 xl:w-[504px] h-fit"
-                  >
-                    <PaywallPreview />
-                  </div>
-                </>
-              </div>
-            </div>
-          </div>
-        </div>
+    <ToolLayoutWithPreview
+      title="Pay Per Article"
+      description={
+        <>
+          Pay Per Article lets visitors unlock gated content with a one-time
+          payment.
+          <br />
+          It provides a clean, customizable interface to configure pricing, and
+          choose how locked content is revealed.
+        </>
+      }
+      additionalDescription={<Divider className="!my-3xl" />}
+      walletStore={{
+        wallet: paywallWallet,
+        actions: paywallWalletActions,
+        load: loadPaywallWallet,
+        persist: persistPaywallWallet,
+      }}
+      toolStoreUtils={{
+        subscribeProfilesToStorage,
+        hydrateProfilesFromStorage,
+        hydrateSnapshotsFromStorage,
+        subscribeProfilesToUpdates,
+      }}
+      walletAddressToolName="pay per article"
+      steps={[
+        {
+          number: 2,
+          label: 'Configure',
+          status: snap.configureStep,
+        },
+        {
+          number: 3,
+          label: 'Build',
+          status: snap.buildStep,
+        },
+      ]}
+      preview={<Preview />}
+      loaderData={{
+        grantResponse,
+        isGrantAccepted,
+        isGrantResponse,
+        OP_WALLET_ADDRESS,
+      }}
+      stepMiddle={
+        <>
+          <PaywallPriceBuilder />
+          <PaywallPlacementBuilder />
+        </>
+      }
+    >
+      <div className="bg-interface-bg-container rounded-sm p-md flex-col gap-md w-full -mt-2 flex">
+        <PaywallBuilder
+          onRefresh={(section) => actions.resetProfileSection(section)}
+        />
       </div>
+    </ToolLayoutWithPreview>
+  )
+}
+
+function Preview() {
+  return (
+    <div
+      id="preview"
+      className="w-full mx-auto xl:mx-0 xl:sticky xl:top-md xl:self-start xl:flex-shrink-0 xl:w-[504px] h-fit"
+    >
+      <PaywallPreview />
     </div>
   )
 }

--- a/frontend/app/routes/paywall.tsx
+++ b/frontend/app/routes/paywall.tsx
@@ -108,7 +108,7 @@ export default function Paywall() {
         { number: 2, label: 'Configure', status: snap.configureStep },
         { number: 3, label: 'Build', status: snap.buildStep },
       ]}
-      preview={<Preview />}
+      preview={<PaywallPreview />}
       loaderData={{
         grantResponse,
         isGrantAccepted,
@@ -128,16 +128,5 @@ export default function Paywall() {
         />
       </div>
     </ToolLayoutWithPreview>
-  )
-}
-
-function Preview() {
-  return (
-    <div
-      id="preview"
-      className="w-full mx-auto xl:mx-0 xl:sticky xl:top-md xl:self-start xl:flex-shrink-0 xl:w-[504px] h-fit"
-    >
-      <PaywallPreview />
-    </div>
   )
 }

--- a/frontend/app/routes/widget.tsx
+++ b/frontend/app/routes/widget.tsx
@@ -1,37 +1,16 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import {
   useLoaderData,
-  useNavigate,
   data,
   type LoaderFunctionArgs,
   type MetaFunction,
 } from 'react-router'
 import { useSnapshot } from 'valtio'
-import { SVGSpinner } from '@/assets'
-import {
-  HeadingCore,
-  ToolsWalletAddress,
-  BuilderBackground,
-  ToolsSecondaryButton,
-  ToolsPrimaryButton,
-  StepsIndicator,
-  MobileStepsIndicator,
-  BuilderProfileTabs,
-} from '@/components'
+import { BuilderBackground, BuilderProfileTabs } from '@/components'
+import { ToolLayoutWithPreview } from '~/components/ToolLayoutWithPreview'
 import { WidgetBuilder } from '~/components/widget/WidgetBuilder'
 import { WidgetPreview } from '~/components/widget/WidgetPreview'
-import { useBodyClass } from '~/hooks/useBodyClass'
-import { useGrantResponseHandler } from '~/hooks/useGrantResponseHandler'
-import { usePathTracker } from '~/hooks/usePathTracker'
-import { useSaveProfile } from '~/hooks/useSaveProfile'
-import { useScrollToWalletAddress } from '~/hooks/useScrollToWalletAddress'
-import { useToolWallet } from '~/hooks/useToolWallet'
-import {
-  toolState,
-  toolActions,
-  persistState,
-  loadState,
-} from '~/stores/toolStore'
+import { toolState, toolActions } from '~/stores/toolStore'
 import { useUIActions } from '~/stores/uiStore'
 import {
   actions,
@@ -87,199 +66,93 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
 export default function Widget() {
   const snap = useSnapshot(toolState)
   const widgetSnap = useSnapshot(widget)
-  const navigate = useNavigate()
   const uiActions = useUIActions()
-  const [walletSnap, walletActions] = useToolWallet({
-    wallet: widgetWallet,
-    actions: widgetWalletActions,
-  })
-  const { save, saveLastAction } = useSaveProfile(widgetWallet)
-  const { walletAddressRef, scrollToWalletAddress } = useScrollToWalletAddress()
-  const [isLoading, setIsLoading] = useState(false)
-  const [isLoadingScript, setIsLoadingScript] = useState(false)
+
   const { grantResponse, isGrantAccepted, isGrantResponse, OP_WALLET_ADDRESS } =
     useLoaderData<typeof loader>()
-  usePathTracker()
-  useBodyClass('has-fixed-action-bar')
 
   useEffect(() => {
     uiActions.setActiveSection('content')
-    const unsubscribeUpdates = subscribeProfilesToUpdates()
-    hydrateProfilesFromStorage()
-    const unsubscribeStorage = subscribeProfilesToStorage()
-    hydrateSnapshotsFromStorage()
-
-    loadState(OP_WALLET_ADDRESS)
-    persistState()
-    loadWidgetWallet()
-    persistWidgetWallet()
-
-    return () => {
-      unsubscribeStorage()
-      unsubscribeUpdates()
-    }
   }, [OP_WALLET_ADDRESS])
 
-  useGrantResponseHandler(grantResponse, isGrantAccepted, isGrantResponse, {
-    onGrantSuccess: saveLastAction,
-  })
-
-  const handleSave = async (action: 'save-success' | 'script') => {
-    if (!walletSnap.isWalletConnected) {
-      walletActions.setConnectWalletStep('error')
-      scrollToWalletAddress()
-      return
-    }
-
-    const isScript = action === 'script'
-    const setLoading = isScript ? setIsLoadingScript : setIsLoading
-
-    setLoading(true)
-    try {
-      await save(action)
-    } finally {
-      setLoading(false)
-    }
-  }
-
   return (
-    <div className="bg-interface-bg-main w-full">
-      <div className="flex flex-col items-center pt-[60px] md:pt-3xl">
-        <div className="w-full max-w-[1280px] px-md">
-          <HeadingCore title="Widget" onBackClick={() => navigate('/')}>
-            The payment widget allows visitors to make one-time payments to
-            support your content directly.
-            <br />
-            It provides a clean, customizable interface for Web Monetization
-            payments.
-            <br />
-            Configure your wallet address to receive payments from your
-            supporters.
-          </HeadingCore>
-          <div className="flex flex-col min-h-[756px]">
-            <div className="flex flex-col xl:flex-row xl:items-start gap-lg">
-              <div
-                id="steps-indicator"
-                className="hidden xl:block w-[60px] flex-shrink-0 pt-md"
-              >
-                <StepsIndicator
-                  steps={[
-                    {
-                      number: 1,
-                      label: 'Connect',
-                      status: walletSnap.walletConnectStep,
-                    },
-                    {
-                      number: 2,
-                      label: 'Build',
-                      status: snap.buildStep,
-                    },
-                  ]}
-                />
-              </div>
+    <ToolLayoutWithPreview
+      title="Widget"
+      description={
+        <>
+          The payment widget allows visitors to make one-time payments to
+          support your content directly.
+          <br />
+          It provides a clean, customizable interface for Web Monetization
+          payments.
+          <br />
+          Configure your wallet address to receive payments from your
+          supporters.
+        </>
+      }
+      walletStore={{
+        wallet: widgetWallet,
+        actions: widgetWalletActions,
+        load: loadWidgetWallet,
+        persist: persistWidgetWallet,
+      }}
+      toolStoreUtils={{
+        subscribeProfilesToStorage,
+        hydrateProfilesFromStorage,
+        hydrateSnapshotsFromStorage,
+        subscribeProfilesToUpdates,
+      }}
+      walletAddressToolName="payment widget"
+      steps={[{ number: 2, label: 'Build', status: snap.buildStep }]}
+      preview={
+        <Preview
+          cdnUrl={snap.cdnUrl}
+          apiUrl={snap.apiUrl}
+          opWallet={snap.opWallet}
+        />
+      }
+      loaderData={{
+        grantResponse,
+        isGrantAccepted,
+        isGrantResponse,
+        OP_WALLET_ADDRESS,
+      }}
+    >
+      <BuilderProfileTabs
+        idPrefix="profile"
+        options={widgetSnap.profileTabs}
+        selectedId={snap.activeTab}
+        onChange={(profileId) => toolActions.setActiveTab(profileId)}
+        onRename={(name) => actions.setProfileName(name)}
+      >
+        <WidgetBuilder
+          onRefresh={(section) => actions.resetProfileSection(section)}
+        />
+      </BuilderProfileTabs>
+    </ToolLayoutWithPreview>
+  )
+}
 
-              <div className="flex flex-col gap-2xl xl:gap-12 flex-1">
-                <div id="wallet-address" ref={walletAddressRef}>
-                  <MobileStepsIndicator
-                    number={1}
-                    label="Connect"
-                    status={walletSnap.walletConnectStep}
-                  />
-                  <ToolsWalletAddress
-                    store={walletSnap}
-                    walletActions={walletActions}
-                    toolName="payment widget"
-                  />
-                </div>
-
-                <div className="flex flex-col xl:flex-row gap-2xl">
-                  <div
-                    id="builder"
-                    className="w-full xl:max-w-[628px] xl:flex-1"
-                  >
-                    <MobileStepsIndicator
-                      number={2}
-                      label="Build"
-                      status={snap.buildStep}
-                    />
-                    <BuilderProfileTabs
-                      idPrefix="profile"
-                      options={widgetSnap.profileTabs}
-                      selectedId={snap.activeTab}
-                      onChange={(profileId) =>
-                        toolActions.setActiveTab(profileId)
-                      }
-                      onRename={(name) => actions.setProfileName(name)}
-                    >
-                      <WidgetBuilder
-                        onRefresh={(section) =>
-                          actions.resetProfileSection(section)
-                        }
-                      />
-                    </BuilderProfileTabs>
-
-                    <div
-                      id="builder-actions"
-                      className="xl:flex xl:items-center xl:justify-end xl:gap-sm xl:mt-lg xl:static xl:bg-transparent xl:p-0 xl:border-0 xl:backdrop-blur-none xl:flex-row
-                                 fixed bottom-0 left-0 right-0 flex flex-col gap-xs px-md sm:px-lg md:px-xl py-md bg-interface-bg-stickymenu/95 backdrop-blur-[20px] border-t border-field-border z-40"
-                    >
-                      <div
-                        id="builder-actions-inner"
-                        className="xl:contents flex flex-col gap-xs mx-auto w-full xl:w-auto xl:p-0 xl:mx-0 xl:flex-row xl:gap-sm"
-                      >
-                        <ToolsSecondaryButton
-                          className="xl:w-[150px] xl:rounded-lg
-                                     w-full min-w-0 border-0 xl:border order-last xl:order-first"
-                          disabled={isLoading}
-                          onClick={() => handleSave('save-success')}
-                        >
-                          <div className="flex items-center justify-center gap-2">
-                            {isLoading && <SVGSpinner className="w-4 h-4" />}
-                            <span>
-                              {isLoading ? 'Saving...' : 'Save edits only'}
-                            </span>
-                          </div>
-                        </ToolsSecondaryButton>
-                        <ToolsPrimaryButton
-                          icon="script"
-                          iconPosition={isLoadingScript ? 'none' : 'left'}
-                          className="xl:w-[250px] xl:rounded-lg
-                                     w-full min-w-0 order-first xl:order-last"
-                          disabled={isLoadingScript}
-                          onClick={() => handleSave('script')}
-                        >
-                          <div className="flex items-center justify-center gap-xs">
-                            {isLoadingScript && (
-                              <SVGSpinner className="w-4 h-4" />
-                            )}
-                            <span>
-                              {isLoadingScript
-                                ? 'Saving...'
-                                : 'Save and generate script'}
-                            </span>
-                          </div>
-                        </ToolsPrimaryButton>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div
-                    id="preview"
-                    className="w-full mx-auto xl:mx-0 xl:sticky xl:top-md xl:self-start xl:flex-shrink-0 xl:w-[504px] h-fit"
-                  >
-                    <BuilderBackground>
-                      <WidgetPreview
-                        serviceUrls={{ cdn: snap.cdnUrl, api: snap.apiUrl }}
-                        opWallet={snap.opWallet}
-                      />
-                    </BuilderBackground>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+function Preview({
+  cdnUrl,
+  apiUrl,
+  opWallet,
+}: {
+  cdnUrl: string
+  apiUrl: string
+  opWallet: string
+}) {
+  return (
+    <div
+      id="preview"
+      className="w-full mx-auto xl:mx-0 xl:sticky xl:top-md xl:self-start xl:flex-shrink-0 xl:w-[504px] h-fit"
+    >
+      <BuilderBackground>
+        <WidgetPreview
+          serviceUrls={{ cdn: cdnUrl, api: apiUrl }}
+          opWallet={opWallet}
+        />
+      </BuilderBackground>
     </div>
   )
 }

--- a/frontend/app/routes/widget.tsx
+++ b/frontend/app/routes/widget.tsx
@@ -143,16 +143,11 @@ function Preview({
   opWallet: string
 }) {
   return (
-    <div
-      id="preview"
-      className="w-full mx-auto xl:mx-0 xl:sticky xl:top-md xl:self-start xl:flex-shrink-0 xl:w-[504px] h-fit"
-    >
-      <BuilderBackground>
-        <WidgetPreview
-          serviceUrls={{ cdn: cdnUrl, api: apiUrl }}
-          opWallet={opWallet}
-        />
-      </BuilderBackground>
-    </div>
+    <BuilderBackground>
+      <WidgetPreview
+        serviceUrls={{ cdn: cdnUrl, api: apiUrl }}
+        opWallet={opWallet}
+      />
+    </BuilderBackground>
   )
 }


### PR DESCRIPTION
Add `ToolLayoutWithPreview`, which abstracts away most of the layout and setup we use individually in each tool.

Update banner, offerwall, widget and paywall routes to use this layout component.

We pass a lot of things as props to keep this abstraction. Can make it even more abstract, but trying to keep the PR as small as possible for now.
Next, I'd like to get rid of `MobileStepsIndicator`, make `StepsIndicator` adapt to mobile layouts. Then we'd simply have 2-3 steps per tool (the wallet address being first common step), and not require `preview` as a prop. Keep it similar to children esentially.