### PR TITLE
fix: replace "profile" with "layout" in user-facing copy

### DIFF
--- a/frontend/app/i18n/locales/en.json
+++ b/frontend/app/i18n/locales/en.json
@@ -9,13 +9,13 @@
   "toolsWalletAddress": {
     "heading.message": "Wallet address",
     "tooltip.ariaLabel": "Why connect your wallet?",
-    "tooltip.message": "Connecting your wallet allows us to save your custom profiles, link them to you as the original author, and verify ownership for future updates.",
+    "tooltip.message": "Connecting your wallet allows us to save your custom layouts, link them to you as the original author, and verify ownership for future updates.",
     "tooltip.message2": "It also enables Web Monetization on your behalf by embedding your wallet address into your web page automatically.",
     "errors.fieldRequired": "This field is required",
     "errors.connectionError": "You have not connected your wallet address yet.",
-    "status.connect": "If you're connecting your wallet address for the first time, you'll start with the default profile. You can then customize and save your profile as needed.",
+    "status.connect": "If you're connecting your wallet address for the first time, you'll start with the default layout. You can then customize and save your layout as needed.",
     "status.noSavedProfiles": "There are no custom edits for the {{toolName}} correlated to this wallet address but you can start customizing when you want.",
-    "status.profilesFetched": "We've loaded your profiles. Feel free to keep customizing your {{toolName}} to fit your style.",
+    "status.profilesFetched": "We've loaded your layouts. Feel free to keep customizing your {{toolName}} to fit your style.",
     "button.loadingLabel": "Connecting...",
     "button.submitLabel": "Continue",
     "button.disconnectAriaLabel": "Disconnect wallet"

--- a/frontend/app/utils/profile-api.ts
+++ b/frontend/app/utils/profile-api.ts
@@ -50,7 +50,7 @@ export async function getToolProfiles<T extends Tool>(
 
   if (!response.ok) {
     throw new ApiError(
-      data.error?.message || 'Failed to fetch profiles',
+      data.error?.message || 'Failed to fetch layouts',
       data.error?.cause?.errors,
       response.status,
     )

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -17,9 +17,9 @@ export const PROFILE_IDS = [PROFILE_A, PROFILE_B, PROFILE_C] as const
 export type ProfileId = (typeof PROFILE_IDS)[number]
 
 export const DEFAULT_PROFILE_NAMES: Record<ProfileId, string> = {
-  version1: 'Default profile 1',
-  version2: 'Default profile 2',
-  version3: 'Default profile 3',
+  version1: 'Default layout 1',
+  version2: 'Default layout 2',
+  version3: 'Default layout 3',
 } as const
 
 export interface Configuration {


### PR DESCRIPTION
Closes https://github.com/interledger/publisher-tools/issues/771

Internally, we'll continue to call them profile/config for now, but for user-facing things, we'll replace with "layout".