### PR TITLE
feat(frontend): use `subject` grant for wallet ownership check

### DIFF
--- a/frontend/app/utils/open-payments.server.ts
+++ b/frontend/app/utils/open-payments.server.ts
@@ -85,6 +85,15 @@ async function createClient(env: Env) {
   return client
 }
 
+// authServers known to support subject (remove once broadly supported)
+const SUBJECT_GRANT_AUTH_SERVERS = new Set<string>([
+  'auth.interledger-test.dev',
+])
+
+function supportsSubjectGrant(walletAddress: WalletAddress): boolean {
+  return SUBJECT_GRANT_AUTH_SERVERS.has(new URL(walletAddress.authServer).host)
+}
+
 export async function createInteractiveGrant(
   env: Env,
   args: {
@@ -95,27 +104,27 @@ export async function createInteractiveGrant(
   const opClient = await createClient(env)
   const clientNonce = crypto.randomUUID()
 
-  try {
-    return await createSubjectGrant({
+  if (supportsSubjectGrant(args.walletAddress)) {
+    return createSubjectGrant({
       walletAddress: args.walletAddress,
       nonce: clientNonce,
-      opClient,
-      redirectUrl: args.redirectUrl,
-    })
-  } catch {
-    return createOutgoingPaymentGrant({
-      walletAddress: args.walletAddress,
-      debitAmount: {
-        value: String(1 * 10 ** args.walletAddress.assetScale),
-        assetCode: args.walletAddress.assetCode,
-        assetScale: args.walletAddress.assetScale,
-      },
-      nonce: clientNonce,
-      paymentId: createId(),
       opClient,
       redirectUrl: args.redirectUrl,
     })
   }
+
+  return createOutgoingPaymentGrant({
+    walletAddress: args.walletAddress,
+    debitAmount: {
+      value: String(1 * 10 ** args.walletAddress.assetScale),
+      assetCode: args.walletAddress.assetCode,
+      assetScale: args.walletAddress.assetScale,
+    },
+    nonce: clientNonce,
+    paymentId: createId(),
+    opClient,
+    redirectUrl: args.redirectUrl,
+  })
 }
 
 async function createSubjectGrant(params: {

--- a/frontend/app/utils/open-payments.server.ts
+++ b/frontend/app/utils/open-payments.server.ts
@@ -6,6 +6,7 @@ import {
   type WalletAddress,
   type AuthenticatedClient,
   isFinalizedGrantWithAccessToken,
+  isFinalizedGrantWithSubject,
   isPendingGrant,
   createAuthenticatedClient,
 } from '@interledger/open-payments'
@@ -93,22 +94,60 @@ export async function createInteractiveGrant(
 ) {
   const opClient = await createClient(env)
   const clientNonce = crypto.randomUUID()
-  const paymentId = createId()
 
-  const outgoingPaymentGrant = await createOutgoingPaymentGrant({
-    walletAddress: args.walletAddress,
-    debitAmount: {
-      value: String(1 * 10 ** args.walletAddress.assetScale),
-      assetCode: args.walletAddress.assetCode,
-      assetScale: args.walletAddress.assetScale,
+  try {
+    return await createSubjectGrant({
+      walletAddress: args.walletAddress,
+      nonce: clientNonce,
+      opClient,
+      redirectUrl: args.redirectUrl,
+    })
+  } catch {
+    return createOutgoingPaymentGrant({
+      walletAddress: args.walletAddress,
+      debitAmount: {
+        value: String(1 * 10 ** args.walletAddress.assetScale),
+        assetCode: args.walletAddress.assetCode,
+        assetScale: args.walletAddress.assetScale,
+      },
+      nonce: clientNonce,
+      paymentId: createId(),
+      opClient,
+      redirectUrl: args.redirectUrl,
+    })
+  }
+}
+
+async function createSubjectGrant(params: {
+  walletAddress: WalletAddress
+  nonce: string
+  opClient: AuthenticatedClient
+  redirectUrl?: string
+}): Promise<PendingGrant> {
+  const { walletAddress, nonce, opClient, redirectUrl } = params
+
+  const grant = await opClient.grant.request(
+    { url: walletAddress.authServer },
+    {
+      subject: {
+        sub_ids: [{ id: walletAddress.id, format: 'uri' }],
+      },
+      interact: {
+        start: ['redirect'],
+        finish: {
+          method: 'redirect',
+          uri: redirectUrl ?? '',
+          nonce,
+        },
+      },
     },
-    nonce: clientNonce,
-    paymentId: paymentId,
-    opClient,
-    redirectUrl: args.redirectUrl,
-  })
+  )
 
-  return outgoingPaymentGrant
+  if (!isPendingGrant(grant)) {
+    throw new Error('Expected interactive subject grant.')
+  }
+
+  return grant
 }
 
 export interface Amount {
@@ -195,11 +234,10 @@ export async function isGrantValidAndAccepted(
     },
   )
 
-  if (!isFinalizedGrantWithAccessToken(continuation)) {
-    return false
-  }
-
-  return !!continuation.access_token.value
+  return (
+    isFinalizedGrantWithSubject(continuation) ||
+    isFinalizedGrantWithAccessToken(continuation)
+  )
 }
 
 async function createHeaders({

--- a/frontend/app/utils/open-payments.server.ts
+++ b/frontend/app/utils/open-payments.server.ts
@@ -89,7 +89,7 @@ export async function createInteractiveGrant(
   env: Env,
   args: {
     walletAddress: WalletAddress
-    redirectUrl?: string
+    redirectUrl: string
   },
 ) {
   const opClient = await createClient(env)
@@ -122,7 +122,7 @@ async function createSubjectGrant(params: {
   walletAddress: WalletAddress
   nonce: string
   opClient: AuthenticatedClient
-  redirectUrl?: string
+  redirectUrl: string
 }): Promise<PendingGrant> {
   const { walletAddress, nonce, opClient, redirectUrl } = params
 
@@ -136,7 +136,7 @@ async function createSubjectGrant(params: {
         start: ['redirect'],
         finish: {
           method: 'redirect',
-          uri: redirectUrl ?? '',
+          uri: redirectUrl,
           nonce,
         },
       },
@@ -165,7 +165,7 @@ type CreateOutgoingPaymentParams = {
 }
 
 async function createOutgoingPaymentGrant(
-  params: CreateOutgoingPaymentParams & { redirectUrl?: string },
+  params: CreateOutgoingPaymentParams & { redirectUrl: string },
 ): Promise<PendingGrant> {
   const {
     walletAddress,


### PR DESCRIPTION
  Closes #638

  ## Summary
  - Save-profile flow now requests a GNAP `subject` grant first to confirm wallet ownership (Rafiki v2.1.0+), so the IDP consent screen reads as an ownership prompt
  - If the wallet's auth server rejects the subject grant (older Rafiki without `subject` support), we automatically fall back to the previous outgoing-payment grant
  - `isGrantValidAndAccepted` accepts either a finalized subject grant or a finalized access-token grant.