### PR TITLE
chore(dep): move pnpm override

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,7 +21,7 @@ export default [
     ...pluginReact.configs.flat.recommended,
     settings: {
       react: {
-        version: 'detect',
+        version: '19',
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -36,11 +36,6 @@
   "resolutions": {
     "esbuild": "^0.28.1"
   },
-  "pnpm": {
-    "overrides": {
-      "wrangler": "^4.100.0"
-    }
-  },
   "engines": {
     "pnpm": "^10.33.0",
     "npm": "pnpm",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   esbuild: ^0.28.1
-  wrangler: ^4.100.0
 
 importers:
 
@@ -1181,7 +1180,7 @@ packages:
       react-server-dom-webpack: ^19.2.3
       typescript: ^5.1.0 || ^6.0.0
       vite: ^5.1.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-      wrangler: ^4.100.0
+      wrangler: ^3.28.2 || ^4.0.0
     peerDependenciesMeta:
       '@react-router/serve':
         optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,6 @@ packages:
 
 onlyBuiltDependencies:
   - '@actions/github-script@https://codeload.github.com/actions/github-script/tar.gz/ed597411d8f924073f98dfc5c65a23a2325f34cd'
+
+overrides:
+  wrangler: ^4.100.0


### PR DESCRIPTION
Resolves warning: _The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.overrides". See https://pnpm.io/settings for the new home of each setting._