### PR TITLE
chore(deps): update prettier

### DIFF
--- a/components/src/paywall/components/form.ts
+++ b/components/src/paywall/components/form.ts
@@ -73,10 +73,12 @@ export class PaywallWalletAddressForm extends LitElement {
         </div>
 
         <button type="submit" ?disabled=${this._loading}>
-          ${this._loading
-            ? html`<wm-dots-loader></wm-dots-loader
-                ><span class="sr-only">${this.ctaText}</span>&nbsp;`
-            : this.ctaText}
+          ${
+            this._loading
+              ? html`<wm-dots-loader></wm-dots-loader
+                  ><span class="sr-only">${this.ctaText}</span>&nbsp;`
+              : this.ctaText
+          }
         </button>
       </form>
     `

--- a/components/src/widget/components/home.ts
+++ b/components/src/widget/components/home.ts
@@ -116,9 +116,11 @@ export class HomeView extends LitElement {
           type="submit"
           ?disabled=${this._isSubmitting}
         >
-          ${this._isSubmitting
-            ? html`<wm-dots-loader></wm-dots-loader>`
-            : this.ctaText || DEFAULT_CTA_TEXT}
+          ${
+            this._isSubmitting
+              ? html`<wm-dots-loader></wm-dots-loader>`
+              : this.ctaText || DEFAULT_CTA_TEXT
+          }
         </button>
       </form>
     `

--- a/components/src/widget/components/initiate.ts
+++ b/components/src/widget/components/initiate.ts
@@ -247,9 +247,11 @@ export class PaymentInitiate extends LitElement {
             @change=${this.onAmountChange}
           ></wm-amount>
 
-          ${this.inputAmount
-            ? this.renderPaymentDetails()
-            : this.renderEmptyState()}
+          ${
+            this.inputAmount
+              ? this.renderPaymentDetails()
+              : this.renderEmptyState()
+          }
         </div>
       </div>
     `
@@ -310,9 +312,11 @@ export class PaymentInitiate extends LitElement {
         @click=${this.onPaymentConfirmed}
         ?disabled=${this.isPreparingPayment}
       >
-        ${this.isPreparingPayment
-          ? html`<wm-dots-loader></wm-dots-loader>`
-          : 'Confirm Payment'}
+        ${
+          this.isPreparingPayment
+            ? html`<wm-dots-loader></wm-dots-loader>`
+            : 'Confirm Payment'
+        }
       </button>
     `
   }

--- a/components/src/widget/components/waiting.ts
+++ b/components/src/widget/components/waiting.ts
@@ -28,10 +28,7 @@ export class PaymentWaiting extends LitElement {
   #interactionCompleted = false
 
   @state() private currentView:
-    | 'authorizing'
-    | 'processing'
-    | 'success'
-    | 'failed' = 'authorizing'
+    'authorizing' | 'processing' | 'success' | 'failed' = 'authorizing'
   @state() private errorMessage = ''
 
   @property({ type: String, attribute: false }) private paymentId = ''
@@ -221,22 +218,26 @@ export class PaymentWaiting extends LitElement {
 
         <div class="interaction-body">
           <div class="title ${titleClass}">${title}</div>
-          ${description
-            ? html`<div class="description">${description}</div>`
-            : nothing}
+          ${
+            description
+              ? html`<div class="description">${description}</div>`
+              : nothing
+          }
           <img src=${image.src} width="122" height="200" alt=${image.alt} />
         </div>
 
-        ${button
-          ? html`
-              <button
-                class="button-container ${button.buttonClass}"
-                @click=${button.handler}
-              >
-                ${button.label}
-              </button>
-            `
-          : nothing}
+        ${
+          button
+            ? html`
+                <button
+                  class="button-container ${button.buttonClass}"
+                  @click=${button.handler}
+                >
+                  ${button.label}
+                </button>
+              `
+            : nothing
+        }
       </div>
     `
   }

--- a/frontend/app/components/banner/BannerPreview.tsx
+++ b/frontend/app/components/banner/BannerPreview.tsx
@@ -7,8 +7,7 @@ import { ToolPreview, type ToolPreviewHandle } from '~/components/ToolPreview'
 import { useBannerProfile } from '~/stores/banner-store'
 
 export type Message =
-  | { action: 'RESET' }
-  | { action: 'UPDATE'; profile: BannerProfile }
+  { action: 'RESET' } | { action: 'UPDATE'; profile: BannerProfile }
 
 export type MessageFromIframe = { type: 'READY' }
 

--- a/frontend/app/components/paywall/PaywallPreview.tsx
+++ b/frontend/app/components/paywall/PaywallPreview.tsx
@@ -8,12 +8,10 @@ import { ToolPreview, type ToolPreviewHandle } from '~/components/ToolPreview'
 import { usePaywallProfile } from '~/stores/paywall-store'
 
 export type Message =
-  | { action: 'RESET' }
-  | { action: 'UPDATE'; profile: PaywallProfile }
+  { action: 'RESET' } | { action: 'UPDATE'; profile: PaywallProfile }
 
 export type MessageFromIframe =
-  | { type: 'READY' }
-  | { type: 'CURRENT_SCREEN'; view: keyof View }
+  { type: 'READY' } | { type: 'CURRENT_SCREEN'; view: keyof View }
 
 export function PaywallPreview() {
   const [currentView, setCurrentView] = useState<keyof View>('home')

--- a/frontend/app/i18n/useTranslation.ts
+++ b/frontend/app/i18n/useTranslation.ts
@@ -3,8 +3,7 @@ import { useI18n, type Translations } from './context'
 type Namespace = keyof Translations
 type GeneralKey = keyof Translations['general'] & string
 type NamespaceKey<NS extends Namespace> = (
-  | keyof Translations[NS]
-  | GeneralKey
+  keyof Translations[NS] | GeneralKey
 ) &
   string
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-react": "^7.37.5",
     "globals": "^17.6.0",
-    "prettier": "^3.8.4",
+    "prettier": "^3.9.3",
     "typescript": "5.9.3",
     "typescript-eslint": "^8.61.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^17.6.0
         version: 17.6.0
       prettier:
-        specifier: ^3.8.4
-        version: 3.8.4
+        specifier: ^3.9.3
+        version: 3.9.4
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -3355,8 +3355,8 @@ packages:
     resolution: {integrity: sha512-E6rsNU1QNJgB3sjj7OANinGncFKuK+164sLXw1/CqBjj/EkXSoSdHCtWQGBNlREIGLnL7IEUEGa08YFVUbrhVg==}
     engines: {node: '>=16'}
 
-  prettier@3.8.4:
-    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+  prettier@3.9.4:
+    resolution: {integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -4987,7 +4987,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.1.1
       pkg-types: 2.3.0
-      prettier: 3.8.4
+      prettier: 3.9.4
       react-refresh: 0.14.2
       react-router: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       semver: 7.7.3
@@ -7263,7 +7263,7 @@ snapshots:
 
   presentable-error@0.0.1: {}
 
-  prettier@3.8.4: {}
+  prettier@3.9.4: {}
 
   process-nextick-args@2.0.1: {}
 


### PR DESCRIPTION
Bumps `prettier` ^3.8.4 → ^3.9.3 and applies the formatting changes prettier 3.9.3 produces.

  ## Changes
  - `prettier` ^3.8.4 → ^3.9.3
  - 7 files reformatted by `pnpm format` to match prettier 3.9.3 output (no logic changes — formatting only)