### PR TITLE
fix(revshare): prevent crash on non-Latin1 wallet address input

### DIFF
--- a/frontend/app/lib/revshare.ts
+++ b/frontend/app/lib/revshare.ts
@@ -38,8 +38,7 @@ export type SharesState = Share[]
  */
 export function getValidShares(shares: Share[]): SharesState {
   return shares.filter(
-    (share) =>
-      share.pointer && Number(share.weight) && share.isValid === true,
+    (share) => share.pointer && Number(share.weight) && share.isValid === true,
   )
 }
 

--- a/frontend/app/lib/revshare.ts
+++ b/frontend/app/lib/revshare.ts
@@ -37,7 +37,10 @@ export type SharesState = Share[]
  * @returns Array of shares that have both pointer and weight
  */
 export function getValidShares(shares: Share[]): SharesState {
-  return shares.filter((share) => share.pointer && Number(share.weight))
+  return shares.filter(
+    (share) =>
+      share.pointer && Number(share.weight) && share.isValid === true,
+  )
 }
 
 export function generateShareId(): string {

--- a/frontend/app/routes/prob-revshare.tsx
+++ b/frontend/app/routes/prob-revshare.tsx
@@ -84,7 +84,10 @@ function Revshare() {
   const handleChangePointer = useCallback(
     (index: number, pointer: string) => {
       setShares((prevShares) =>
-        changeList(prevShares, index, { pointer: pointer.trim() }),
+        changeList(prevShares, index, {
+          pointer: pointer.trim(),
+          isValid: false,
+        }),
       )
     },
     [setShares],


### PR DESCRIPTION
  ## Summary
 Pasting/typing non-Latin1 characters into a wallet address field crashed the page via `btoa`. Fix: reset `isValid` on each pointer change and filter it out in `getValidShares`, so the URL encode is skipped until the debounced validation passes.
 
 Closes #805 