### PR TITLE
fix(InputField): remove the required error on wallet address input

### DIFF
--- a/frontend/app/components/redesign/components/InputField.tsx
+++ b/frontend/app/components/redesign/components/InputField.tsx
@@ -43,14 +43,6 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
     const ariaDescriptionId =
       ariaDescription && !error ? `${fieldId}-aria-desc` : undefined
 
-    const getDisplayError = (): string | string[] | undefined => {
-      if (required && !props.value) {
-        return 'This field is required'
-      }
-
-      return error
-    }
-
     const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
       const trimmed = e.target.value.trim()
       if (trimmed !== e.target.value) {
@@ -61,7 +53,7 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
       onBlur?.(e)
     }
 
-    const displayError = getDisplayError()
+    const displayError = error
     return (
       <div className="space-y-2xs">
         {label && (

--- a/frontend/app/components/redesign/components/LinkTagGenerator.tsx
+++ b/frontend/app/components/redesign/components/LinkTagGenerator.tsx
@@ -79,9 +79,9 @@ export const LinkTagGenerator = () => {
       <div>
         <InputField
           id="paymentPointer"
-          label="Your payment pointer/wallet address"
+          label="Payment pointer or wallet address"
           required
-          placeholder="Fill in your payment pointer/wallet address"
+          placeholder="https://walletprovider.com/MyWallet"
           value={pointerInput}
           onChange={(e) => handleOnChange(e)}
           error={invalidUrl ? error : ''}

--- a/frontend/app/components/redesign/components/LinkTagGenerator.tsx
+++ b/frontend/app/components/redesign/components/LinkTagGenerator.tsx
@@ -34,6 +34,13 @@ export const LinkTagGenerator = () => {
       setInvalidUrl(false)
       setError('')
 
+      if (!pointerInput.trim()) {
+        setInvalidUrl(true)
+        setError('Please enter a payment pointer or wallet address')
+        setIsLoading(false)
+        return
+      }
+
       try {
         const validatedPointer = await validateAndConfirmPointer(pointerInput)
         setParsedLinkTag(htmlEncodePointer(validatedPointer))


### PR DESCRIPTION
  ## Summary
  - `InputField` was rendering "This field is required" on any empty `required` field before the user interacted with it, so users saw a validation error on initial page load
  - Removed the auto-generated required error

  Closes #812
