### PR TITLE
fix(paywall): iOS lock page scroll and add dvh for coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,4 @@ build
 .react-router/
 
 # Local CDN embed test harness
-cdn/public/embed-test.html
+cdn/public/sandbox/

--- a/components/src/paywall/index.ts
+++ b/components/src/paywall/index.ts
@@ -285,12 +285,10 @@ export class Paywall extends LitElement {
     } = this.#config
 
     const fontBaseUrl = new URL('/assets/fonts/', this.#controller.cdnUrl).href
-    const vhUnit = CSS.supports('height', '100dvh') ? 'dvh' : 'vh'
 
     applyFontFamily(this, font.name, 'paywall', fontBaseUrl)
     this.dataset.fontSize = font.size
-    this.style.setProperty('--wmt-height', `${coverage.value}${vhUnit}`)
-    this.style.setProperty('--wmt-viewport-height', `100${vhUnit}`)
+    this.style.setProperty('--wmt-height', `${coverage.value}`)
     this.style.setProperty('--wmt-background', colors.background as string)
     this.style.setProperty('--wmt-theme', colors.theme as string)
     this.style.setProperty('--wmt-color', colors.text)

--- a/components/src/paywall/index.ts
+++ b/components/src/paywall/index.ts
@@ -51,6 +51,9 @@ export class Paywall extends LitElement {
 
   #scrollLockY: number | null = null
 
+  // iOS Safari ignores `overflow: hidden` on <body>; pin it with
+  // `position: fixed` at -scrollY and restore on unlock. See the
+  // `body-scroll-lock` library for reference of technique
   #lockPageScroll() {
     if (this.#scrollLockY !== null) return
     const y = window.scrollY

--- a/components/src/paywall/index.ts
+++ b/components/src/paywall/index.ts
@@ -46,7 +46,38 @@ export class Paywall extends LitElement {
   }
 
   disconnectedCallback(): void {
+    this.#unlockPageScroll()
+  }
+
+  #scrollLockY: number | null = null
+
+  #lockPageScroll() {
+    if (this.#scrollLockY !== null) return
+    const y = window.scrollY
+    const scrollbarWidth =
+      window.innerWidth - document.documentElement.clientWidth
+    this.#scrollLockY = y
+    document.body.style.overflow = 'hidden'
+    document.body.style.position = 'fixed'
+    document.body.style.top = `-${y}px`
+    document.body.style.left = '0'
+    document.body.style.right = '0'
+    if (scrollbarWidth > 0) {
+      document.body.style.paddingRight = `${scrollbarWidth}px`
+    }
+  }
+
+  #unlockPageScroll() {
+    if (this.#scrollLockY === null) return
+    const y = this.#scrollLockY
+    this.#scrollLockY = null
     document.body.style.overflow = ''
+    document.body.style.position = ''
+    document.body.style.top = ''
+    document.body.style.left = ''
+    document.body.style.right = ''
+    document.body.style.paddingRight = ''
+    window.scrollTo(0, y)
   }
 
   async #init() {
@@ -116,7 +147,7 @@ export class Paywall extends LitElement {
     if (!this._ready) return nothing
     if (this.#entitlement.entitlement === 'has-access') return nothing
     if (!this._delayComplete) return nothing
-    document.body.style.overflow = 'hidden'
+    this.#lockPageScroll()
 
     return html`<div>${this.#render()}</div> `
   }
@@ -212,6 +243,7 @@ export class Paywall extends LitElement {
 
   #hidePaywall() {
     this.dispatchEvent(new CustomEvent('paywall_hide'))
+    this.#unlockPageScroll()
     this.#controller.remove(this)
   }
 
@@ -250,9 +282,12 @@ export class Paywall extends LitElement {
     } = this.#config
 
     const fontBaseUrl = new URL('/assets/fonts/', this.#controller.cdnUrl).href
+    const vhUnit = CSS.supports('height', '100dvh') ? 'dvh' : 'vh'
+
     applyFontFamily(this, font.name, 'paywall', fontBaseUrl)
     this.dataset.fontSize = font.size
-    this.style.setProperty('--wmt-height', `${coverage.value}vh`)
+    this.style.setProperty('--wmt-height', `${coverage.value}${vhUnit}`)
+    this.style.setProperty('--wmt-viewport-height', `100${vhUnit}`)
     this.style.setProperty('--wmt-background', colors.background as string)
     this.style.setProperty('--wmt-theme', colors.theme as string)
     this.style.setProperty('--wmt-color', colors.text)

--- a/components/src/paywall/styles.css
+++ b/components/src/paywall/styles.css
@@ -2,7 +2,9 @@
   width: 100%;
   position: fixed;
   display: flex;
-  align-items: end;
+  flex-direction: column;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   inset: 0;
   font-family: var(--font-family);
   font-size: calc(1rem * var(--font-scale, 1));
@@ -29,7 +31,8 @@
   background: linear-gradient(
     to bottom,
     rgba(0, 0, 0, 0) 0%,
-    rgba(0, 0, 0, 0.75) calc(100vh - var(--coverage))
+    rgba(0, 0, 0, 0.75)
+      calc(var(--wmt-viewport-height, 100vh) - var(--coverage))
   );
   z-index: -1;
 }
@@ -39,6 +42,7 @@
   color: var(--color);
   width: 100%;
   min-height: var(--coverage);
+  margin-top: auto;
   display: flex;
   flex-direction: column;
 }

--- a/components/src/paywall/styles.css
+++ b/components/src/paywall/styles.css
@@ -31,8 +31,7 @@
   background: linear-gradient(
     to bottom,
     rgba(0, 0, 0, 0) 0%,
-    rgba(0, 0, 0, 0.75)
-      calc(var(--wmt-viewport-height, 100vh) - var(--coverage))
+    rgba(0, 0, 0, 0.75) calc((100 * var(--wmt-vh)) - var(--coverage))
   );
   z-index: -1;
 }

--- a/components/src/paywall/vars.css
+++ b/components/src/paywall/vars.css
@@ -3,10 +3,17 @@
   --background: var(--wmt-background, #ffffff);
   --color: var(--wmt-color, #6b6e76);
   --theme: var(--wmt-theme, #56b7b5);
-  --coverage: var(--wmt-height, 50vh);
+  --wmt-vh: 1vh;
+  --coverage: calc(var(--wmt-height, 50) * var(--wmt-vh));
   --border-radius: var(--wmt-border-radius, 1rem);
 
   --color-error: #e51d25;
+}
+
+@supports (height: 100dvh) {
+  :host {
+    --wmt-vh: 1dvh;
+  }
 }
 
 * {


### PR DESCRIPTION
## Summary

- Fixes an issue found in testing where the user was still able to scroll beneath the underlying contents of the page that had the paywall. Found when the keyboard appeared upon entering the wallet address to pay for the content.
- Switched to [`dvh`](https://medium.com/@tharunbalaji110/understanding-mobile-viewport-units-a-complete-guide-to-svh-lvh-and-dvh-0c905d96e21a) to adjust properly when user opens keyboard. Also, added fallback for `vh` for older devices
- Added abilitiy for paywall to be scrollable in cases where the content of the paywall exceeds the visible area

## Tested
- Tested on iOS Simulator and on physical iPhone 17 device
- Tested to make sure that desktop and tablet implementations weren't affected by changing `document.body` CSS properties

Split from #809. Related to #808.