### PR TITLE
fix: standardize wallet address labels across all tools (#206)

### DIFF
--- a/frontend/app/components/redesign/components/LinkTagGenerator.tsx
+++ b/frontend/app/components/redesign/components/LinkTagGenerator.tsx
@@ -36,7 +36,7 @@ export const LinkTagGenerator = () => {
 
       if (!pointerInput.trim()) {
         setInvalidUrl(true)
-        setError('Please enter a payment pointer or wallet address')
+        setError('Wallet address is required')
         setIsLoading(false)
         return
       }
@@ -86,7 +86,7 @@ export const LinkTagGenerator = () => {
       <div>
         <InputField
           id="paymentPointer"
-          label="Payment pointer or wallet address"
+          label="Wallet address"
           required
           placeholder="https://walletprovider.com/MyWallet"
           value={pointerInput}

--- a/frontend/app/components/redesign/components/revshare/RevShareInfo.tsx
+++ b/frontend/app/components/redesign/components/revshare/RevShareInfo.tsx
@@ -39,7 +39,7 @@ export const RevShareInfo = () => {
           Define a revshare
         </p>
         <p className="text-sm leading-sm text-field-helpertext-default">
-          Enter each payment pointer and wallet address that will receive a
+          Enter each wallet address that will receive a
           split of the revenue into the table.
           <br />
           Names are optional.

--- a/frontend/app/components/redesign/components/revshare/RevShareInfo.tsx
+++ b/frontend/app/components/redesign/components/revshare/RevShareInfo.tsx
@@ -39,8 +39,8 @@ export const RevShareInfo = () => {
           Define a revshare
         </p>
         <p className="text-sm leading-sm text-field-helpertext-default">
-          Enter each wallet address that will receive a
-          split of the revenue into the table.
+          Enter each wallet address that will receive a split of the revenue
+          into the table.
           <br />
           Names are optional.
           <br />

--- a/frontend/app/components/redesign/components/revshare/ShareInput.tsx
+++ b/frontend/app/components/redesign/components/revshare/ShareInput.tsx
@@ -63,9 +63,9 @@ export const ShareInputHeader = ({ showDelete }: { showDelete: boolean }) => {
         <div
           role="columnheader"
           id="col-payment-pointer"
-          aria-label="Wallet address or payment pointer for recipient, required field"
+          aria-label="Wallet address for recipient, required field"
         >
-          Wallet Address/Payment Pointer
+          Wallet address
         </div>
         <div
           role="columnheader"
@@ -185,7 +185,7 @@ export const ShareInput = React.memo(
           aria-labelledby="col-payment-pointer"
         >
           <label htmlFor={pointerInputId} className="sr-only">
-            Wallet Address or Payment Pointer
+            Wallet address
           </label>
           <InputField
             id={pointerInputId}
@@ -196,7 +196,7 @@ export const ShareInput = React.memo(
             }
             required
             error={error}
-            ariaDescription="Enter a valid wallet address or payment pointer for this recipient"
+            ariaDescription="Enter a valid wallet address for this recipient"
             className={cx(
               showIcon && 'pr-10',
               hasError && 'border-field-border-error',


### PR DESCRIPTION
## What

Standardizes the wallet address input label, aria-labels, column header, and error message across the Link Tag Generator, Probabilistic Revenue Share, and related components.

**Changes:**

| Component | Before | After |
|-----------|--------|-------|
| LinkTagGenerator label | `Payment pointer or wallet address` | `Wallet address` |
| LinkTagGenerator empty error | `Please enter a payment pointer or wallet address` | `Wallet address is required` |
| ShareInput column header | `Wallet Address/Payment Pointer` | `Wallet address` |
| ShareInput aria-label | `Wallet address or payment pointer for recipient, required field` | `Wallet address for recipient, required field` |
| ShareInput sr-only label | `Wallet Address or Payment Pointer` | `Wallet address` |
| ShareInput ariaDescription | `Enter a valid wallet address or payment pointer for this recipient` | `Enter a valid wallet address for this recipient` |
| RevShareInfo description | `Enter each payment pointer and wallet address` | `Enter each wallet address` |

## Why

Four publisher tools used inconsistent labels for the same input field (wallet address). The Banner, Widget, and OfferWall tools already used `Wallet address` consistently. This PR brings the Link Tag Generator and Probabilistic Revenue Share tools in line.

## Testing

- All label/aria-attribute changes are self-contained string replacements
- No functional changes — validation logic, placeholder text, and error messages from wallet address validation remain unchanged
- Link Tag Generator still shows `https://walletprovider.com/MyWallet` as the placeholder, matching other tools

Part of #206