### PR TITLE
chore(api): better commands to run d1 database migrations

### DIFF
--- a/api/migrations/README.md
+++ b/api/migrations/README.md
@@ -5,11 +5,13 @@ These "migration" scripts set up the database. See [Cloudflare D1 docs](https://
 ## Applying migrations
 
 During development:
+
 ```bash
 pnpm -C api migrate
 ```
 
 For production:
+
 ```bash
 pnpm -C api migrate:prod
 ```

--- a/api/migrations/README.md
+++ b/api/migrations/README.md
@@ -1,17 +1,15 @@
 # Database Migrations
 
-These "migration" scripts set up the database. Each script is to be run in order, with each subsequent one building on the previous ones. Each script may have a "down" script (`xyz.down.sql` files) to rollback in case of errors. In general, if the changes that a SQL script wants to apply are already applied, its responsibility of the script to do nothing.
-
-See [Cloudflare D1 docs](https://developers.cloudflare.com/d1/get-started/#populate-your-d1-database) for an idea.
+These "migration" scripts set up the database. See [Cloudflare D1 docs](https://developers.cloudflare.com/d1/reference/migrations/) for details.
 
 ## Applying migrations
 
-1. `cd api`
-2. During development:
-   ```bash
-   pnpm db ./migrations/XYZ-abc.sql
-   ```
-   For production:
-   ```bash
-   pnpm db:prod ./migrations/XYZ-abc.sql
-   ```
+During development:
+```bash
+pnpm -C api migrate
+```
+
+For production:
+```bash
+pnpm -C api migrate:prod
+```

--- a/api/package.json
+++ b/api/package.json
@@ -9,8 +9,8 @@
     "prepare": "wrangler types",
     "test": "vitest run",
     "test:watch": "vitest",
-    "db": "wrangler d1 --persist-to ../.wrangler execute publisher-tools --local --file",
-    "db:prod": "wrangler d1 execute publisher-tools --remote --file",
+    "migrate": "wrangler d1 migrations apply publisher-tools --local --persist-to  ../.wrangler",
+    "migrate:prod": "wrangler d1 migrations apply publisher-tools --remote",
     "deploy": "wrangler deploy"
   },
   "keywords": [],

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -11,7 +11,7 @@ kv_namespaces = [
 ]
 
 d1_databases = [
-  { binding = "PUBLISHER_TOOLS_DB", database_name = "publisher-tools", database_id = "e1d3faf9-7227-4e5f-8dfc-442fd481814f" }
+  { binding = "PUBLISHER_TOOLS_DB", database_name = "publisher-tools", database_id = "e1d3faf9-7227-4e5f-8dfc-442fd481814f", migrations_dir = "./migrations" }
 ]
 
 [dev]


### PR DESCRIPTION
Instead of running each script manually, use `wrangler d1 migrations apply` command.
I've ran this on production database.