### PR TITLE
fix(paywall): ensure resume payment verification, add robustness

### DIFF
--- a/cdn/src/paywall.ts
+++ b/cdn/src/paywall.ts
@@ -110,12 +110,31 @@ function main() {
       return res
     },
     async *getStatus(paymentId, signal) {
+      if (
+        paramsFromUrl.result === 'failure' &&
+        paramsFromUrl.paymentId === paymentId
+      ) {
+        storage.postPayment.delete(pageUrl)
+        yield { type: 'GRANT_REJECTED' }
+        return
+      }
+
       const url = new URL(`/paywall/payment-status/${paymentId}`, API_URL).href
       while (true) {
         try {
           signal?.throwIfAborted()
           const res = await fetch(url, { signal })
           if (!res.ok) {
+            if (res.status === 404) {
+              storage.postPayment.delete(pageUrl)
+              yield {
+                type: 'PAYMENT_DONE',
+                outgoingPaymentId: '',
+                result: 'failure',
+                error: { code: 'NOT_FOUND', message: 'Payment not found' },
+              }
+              break
+            }
             throw new Error(`Payment status check failed: HTTP ${res.status}`)
           }
 
@@ -148,7 +167,7 @@ function main() {
     },
   })
 
-  handlePageLoad(pageUrl, paramsFromUrl, actions)
+  handlePageLoad(pageUrl, actions)
   document.body.appendChild(element)
 }
 
@@ -185,22 +204,10 @@ function handlePageUrlOnLoad() {
   return res
 }
 
-type PageLoadParams = ReturnType<typeof handlePageUrlOnLoad>
-
-function handlePageLoad(
-  pageUrl: string,
-  params: PageLoadParams,
-  actions: Actions,
-) {
+function handlePageLoad(pageUrl: string, actions: Actions) {
   const stored = storage.postPayment.get(pageUrl)
   // must be set during initiatePayment; is removed on failure/completion
   if (!stored) return
-
-  // params are empty after page reload (available only on first load)
-  if (params.result === 'failure') {
-    storage.postPayment.delete(pageUrl)
-    return
-  }
 
   const { sender, paymentId } = stored
   actions.setView('verify', { sender, paymentId })

--- a/cdn/src/paywall.ts
+++ b/cdn/src/paywall.ts
@@ -130,6 +130,7 @@ function main() {
             status.type === 'PAYMENT_DONE' ||
             status.type === 'GRANT_REJECTED'
           ) {
+            storage.postPayment.delete(pageUrl)
             break
           } else {
             throw new Error('Unknown payment status: ' + JSON.stringify(status))
@@ -191,14 +192,18 @@ function handlePageLoad(
   params: PageLoadParams,
   actions: Actions,
 ) {
-  if (params.paymentId && params.result === 'success') {
-    const stored = storage.postPayment.get(pageUrl, params)
-    if (stored) {
-      const { sender, paymentId } = stored
-      actions.setView('verify', { sender, paymentId })
-      storage.postPayment.delete(pageUrl)
-    }
+  const stored = storage.postPayment.get(pageUrl)
+  // must be set during initiatePayment; is removed on failure/completion
+  if (!stored) return
+
+  // params are empty after page reload (available only on first load)
+  if (params.result === 'failure') {
+    storage.postPayment.delete(pageUrl)
+    return
   }
+
+  const { sender, paymentId } = stored
+  actions.setView('verify', { sender, paymentId })
 }
 
 const storage = {
@@ -228,7 +233,7 @@ const storage = {
         JSON.stringify({ data, ts: Date.now() }),
       )
     },
-    get(pageUrl: string, params: PageLoadParams) {
+    get(pageUrl: string) {
       const stored = window.localStorage.getItem(
         `wmt-paywall-payment:${pageUrl}`,
       )
@@ -236,15 +241,14 @@ const storage = {
 
       try {
         const parsed = JSON.parse(stored)
-        if (!parsed.ts || !parsed.data) {
+        if (!parsed.ts || !parsed.data?.sender || !parsed.data?.paymentId) {
           throw new Error('Invalid stored data')
         }
-        // TODO: add more validation, check recency too
-        if (!parsed.data.sender || !parsed.data.paymentId) {
-          throw new Error('Invalid stored data')
-        }
-        if (parsed.data.paymentId !== params.paymentId) {
-          throw new Error('Stored data is for different paymentId')
+        const MAX_AGE_MS = 2 * 60 * 60 * 1000
+        if (Date.now() - parsed.ts > MAX_AGE_MS) {
+          // don't trust too stale data
+          this.delete(pageUrl)
+          return null
         }
         return {
           sender: parsed.data.sender as WalletAddressInfo,

--- a/components/src/paywall/components/verify.ts
+++ b/components/src/paywall/components/verify.ts
@@ -62,12 +62,27 @@ export class PaywallVerify extends LitElement {
         // keep Verifying
         continue
       }
-      if (status.type === 'PAYMENT_DONE') {
+      if (status.type === 'PAYMENT_DONE' && status.result === 'success') {
         const detail: Events['payment_confirmed'] = {
           paymentId: this.paymentId,
           sender: this.sender,
         }
         this.dispatchEvent(new CustomEvent('payment_confirmed', { detail }))
+        break
+      }
+      if (status.type === 'PAYMENT_DONE' || status.type === 'GRANT_REJECTED') {
+        let errorCode = 'UNKNOWN'
+        if (status.type === 'GRANT_REJECTED') {
+          errorCode = status.type
+        } else if (status.error?.code) {
+          errorCode = status.error.code
+        }
+        const detail: Events['payment_failed'] = {
+          paymentId: this.paymentId,
+          sender: this.sender,
+          errorCode,
+        }
+        this.dispatchEvent(new CustomEvent('payment_failed', { detail }))
         break
       }
       throw new Error('Invalid payment status')
@@ -79,6 +94,11 @@ type Events = {
   payment_confirmed: {
     paymentId: string
     sender?: WalletAddressInfo
+  }
+  payment_failed: {
+    paymentId: string
+    sender?: WalletAddressInfo
+    errorCode: string
   }
 }
 export type { Events as PaymentVerifyEvents }

--- a/components/src/paywall/components/verify.ts
+++ b/components/src/paywall/components/verify.ts
@@ -39,7 +39,10 @@ export class PaywallVerify extends LitElement {
   }
 
   firstUpdated() {
-    void this.#startVerify()
+    void this.#startVerify().catch((err) => {
+      console.error('Payment verification failed', err)
+      this.#fail('VERIFY_FAILED')
+    })
   }
 
   render() {
@@ -77,16 +80,20 @@ export class PaywallVerify extends LitElement {
         } else if (status.error?.code) {
           errorCode = status.error.code
         }
-        const detail: Events['payment_failed'] = {
-          paymentId: this.paymentId,
-          sender: this.sender,
-          errorCode,
-        }
-        this.dispatchEvent(new CustomEvent('payment_failed', { detail }))
+        this.#fail(errorCode)
         break
       }
       throw new Error('Invalid payment status')
     }
+  }
+
+  #fail(errorCode: string) {
+    const detail: Events['payment_failed'] = {
+      paymentId: this.paymentId,
+      sender: this.sender,
+      errorCode,
+    }
+    this.dispatchEvent(new CustomEvent('payment_failed', { detail }))
   }
 }
 

--- a/components/src/paywall/index.ts
+++ b/components/src/paywall/index.ts
@@ -180,6 +180,7 @@ export class Paywall extends LitElement {
         .paymentId=${this._view.data.paymentId}
         .controller=${this.#controller}
         @payment_confirmed=${this.#onPaymentConfirmed}
+        @payment_failed=${this.#onPaymentFailed}
       ></wmt-paywall-verify>`
     }
 
@@ -235,6 +236,11 @@ export class Paywall extends LitElement {
       amount: this.#price,
       note: this.defaultNote,
     })
+  }
+
+  #onPaymentFailed(ev: CustomEvent<PaymentVerifyEvents['payment_failed']>) {
+    console.warn('payment_failed', ev.detail.paymentId, ev.detail.errorCode)
+    this.#setView('home', undefined)
   }
 
   async #onPaymentConfirmed(

--- a/components/src/paywall/index.ts
+++ b/components/src/paywall/index.ts
@@ -99,13 +99,17 @@ export class Paywall extends LitElement {
     void this.showAfterDelay(connectedAt).then(() => {
       this.hidden = false
     })
-    if (entitlement.entitlement === 'auth-required') {
+    if (entitlement.entitlement === 'has-access') {
+      this.#hidePaywall()
+    } else if (this._view.type === 'verify') {
+      // If user already is here before checkEntitlement() resolved, trust that
+      // over our own (possibly) stale/racy entitlement read rather than sending
+      // user back to home/form mid-verification.
+    } else if (entitlement.entitlement === 'auth-required') {
       this.#setView('form', {
         walletAddress: this.#controller.senderWalletAddressUrl ?? undefined,
         isAuthMode: true,
       })
-    } else if (entitlement.entitlement === 'has-access') {
-      this.#hidePaywall()
     } else if (entitlement.entitlement === 'pending') {
       this.#setView('verify', { paymentId: entitlement.paymentId! })
     }
@@ -149,7 +153,7 @@ export class Paywall extends LitElement {
   render() {
     if (!this._ready) return nothing
     if (this.#entitlement.entitlement === 'has-access') return nothing
-    if (!this._delayComplete) return nothing
+    if (!this._delayComplete && this._view.type !== 'verify') return nothing
     this.#lockPageScroll()
 
     return html`<div>${this.#render()}</div> `


### PR DESCRIPTION
Final improvements to https://github.com/interledger/publisher-tools/issues/670

Added some robustness fixes for paywall post-payment flow, e.g., refreshing page during verification.
Avoid triggering other screens and stop verification flow if already in verification flow.
On page refresh, always start from "verify" screen (which will handle logic post-load), if we've some last payment stored.
Better error handling - make space for "on payment failed" handlers - like analytics, showing user error message.