### PR TITLE
chore(ci): granular GitHub workflow permissions and use env variables

### DIFF
--- a/.github/workflows/deploy-worker/action.yml
+++ b/.github/workflows/deploy-worker/action.yml
@@ -78,10 +78,12 @@ runs:
       if: ${{ inputs.skip-deploy == 'false' && (inputs.changed == 'true' || inputs.mode == 'production') }}
       id: command
       shell: bash
+      env:
+        DEPLOY_MODE: ${{ inputs.mode }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
-        DEPLOY_MODE='${{ inputs.mode }}'
         case "$DEPLOY_MODE" in
-          preview)    DEPLOY_COMMAND="versions upload --preview-alias pr${{ github.event.pull_request.number }}" ;;
+          preview)    DEPLOY_COMMAND="versions upload --preview-alias pr${PR_NUMBER}" ;;
           staging)    DEPLOY_COMMAND="versions upload --preview-alias staging" ;;
           production) DEPLOY_COMMAND="deploy" ;;
         esac
@@ -107,15 +109,15 @@ runs:
     - name: Get deploy URL
       id: get-url
       shell: bash
+      env:
+        DEPLOY_MODE: ${{ inputs.mode }}
+        URL_ORIGIN: ${{ inputs.origin }}
+        DID_DEPLOY: ${{ inputs.changed }}
+        DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
+        DEPLOY_URL_ALIAS: ${{ steps.deploy.outputs.deployment-alias-url }}
       # if `deploy` was run: set output versioned-url=deployment-url, and url=deployment-alias-url, and did-deploy='true'
       # if not, set did-deploy='false', url=versioned-url=staging-url if mode=preview|staging; url=versioned-url=production-url if mode=production
       run: |
-        DEPLOY_MODE='${{ inputs.mode }}'
-        URL_ORIGIN='${{ inputs.origin }}'
-        DID_DEPLOY='${{ inputs.changed }}'
-        DEPLOY_URL='${{ steps.deploy.outputs.deployment-url }}'
-        DEPLOY_URL_ALIAS='${{ steps.deploy.outputs.deployment-alias-url }}'
-
         echo "did-deploy=$DID_DEPLOY" >> $GITHUB_OUTPUT
 
         if [[ "$DID_DEPLOY" = 'true' ]]; then

--- a/.github/workflows/deploy-worker/action.yml
+++ b/.github/workflows/deploy-worker/action.yml
@@ -80,7 +80,7 @@ runs:
       shell: bash
       env:
         DEPLOY_MODE: ${{ inputs.mode }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
       run: |
         case "$DEPLOY_MODE" in
           preview)    DEPLOY_COMMAND="versions upload --preview-alias pr${PR_NUMBER}" ;;

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ defaults:
     shell: bash
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:
@@ -30,7 +31,7 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const script = await import('${{ github.workspace }}/.github/scripts/check-deploy-permissions.ts');
+            const script = await import(`${process.env.GITHUB_WORKSPACE}/.github/scripts/check-deploy-permissions.ts`);
             await script.default({ core, context });
 
       - uses: ./.github/workflows/setup
@@ -67,9 +68,10 @@ jobs:
 
       - name: Get deploy mode
         id: deploy-mode
+        env:
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_REF: ${{ github.ref }}
         run: |
-          GH_EVENT_NAME='${{ github.event_name }}'
-          GH_REF='${{ github.ref }}'
           mode="preview"
           if [[ "$GH_EVENT_NAME" == 'push' ]]; then
             [[ "$GH_REF" == 'refs/heads/main' ]] && mode="staging"
@@ -142,6 +144,16 @@ jobs:
         if: always()
         uses: actions/github-script@v9
         id: summary
+        env:
+          API_URL: ${{ steps.api.outputs.url }}
+          API_VERSIONED_URL: ${{ steps.api.outputs.versioned-url }}
+          API_OUTCOME: ${{ steps.api.outcome }}
+          CDN_URL: ${{ steps.cdn.outputs.url }}
+          CDN_VERSIONED_URL: ${{ steps.cdn.outputs.versioned-url }}
+          CDN_OUTCOME: ${{ steps.cdn.outcome }}
+          FRONTEND_URL: ${{ steps.frontend.outputs.url }}
+          FRONTEND_VERSIONED_URL: ${{ steps.frontend.outputs.versioned-url }}
+          FRONTEND_OUTCOME: ${{ steps.frontend.outcome }}
         with:
           script: |
             core.summary.addHeading('Deployment results', 'h2');
@@ -149,13 +161,13 @@ jobs:
             core.summary.addRaw(`
             | Worker | Alias | URL  | Outcome |
             | ------ | --- | --- | --- |
-            | API    | ${getTableText('${{ steps.api.outputs.url }}', '${{ steps.api.outputs.versioned-url }}', '${{ steps.api.outcome }}')} |
-            | CDN    | ${getTableText('${{ steps.cdn.outputs.url }}', '${{ steps.cdn.outputs.versioned-url }}', '${{ steps.cdn.outcome }}')} |
-            | App    | ${getTableText('${{ steps.frontend.outputs.url }}', '${{ steps.frontend.outputs.versioned-url }}', '${{ steps.frontend.outcome }}')} |
+            | API    | ${getTableText(process.env.API_URL, process.env.API_VERSIONED_URL, process.env.API_OUTCOME)} |
+            | CDN    | ${getTableText(process.env.CDN_URL, process.env.CDN_VERSIONED_URL, process.env.CDN_OUTCOME)} |
+            | App    | ${getTableText(process.env.FRONTEND_URL, process.env.FRONTEND_VERSIONED_URL, process.env.FRONTEND_OUTCOME)} |
             `, true);
 
-            const repoUrl = '${{ github.server_url }}/${{ github.repository }}';
-            const runId = '${{ github.run_id }}';
+            const repoUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}`;
+            const runId = process.env.GITHUB_RUN_ID;
             core.summary.addSeparator();
             core.summary.addLink(`Logs #${runId}`, `${repoUrl}/actions/runs/${runId}`);
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -9,6 +9,9 @@ on:
       - opened
       - synchronize
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -8,6 +8,9 @@ on:
       - opened
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   check-pr-title:
     name: Check PR Title


### PR DESCRIPTION
Adds an explicit least-privilege `permissions:` block to the workflows that previously had none. Each is scoped to only what its steps actually use.

Routes `${{ }}` values through `env` instead of interpolating them directly.